### PR TITLE
defaultProps overrides undefined props from owner

### DIFF
--- a/src/__tests__/defaultProps-test.js
+++ b/src/__tests__/defaultProps-test.js
@@ -27,4 +27,12 @@ describe('defaultProps()', () => {
 
     expect(base.props).to.eql({ so: 'do', la: 'ti' });
   });
+
+  it('it overrides undefined owner props', () => {
+    const tree = renderIntoDocument(<DoReMi la={undefined} />);
+    const base = findRenderedComponentWithType(tree, BaseComponent);
+
+    expect(base.props).to.eql({ so: 'do', la: 'fa' });
+  });
+
 });

--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -7,8 +7,10 @@ const defaultProps = (props, BaseComponent) => (
   class extends React.Component {
     static displayName = wrapDisplayName(BaseComponent, 'defaultProps');
 
+    static defaultProps = props;
+
     render() {
-      return <BaseComponent {...props} {...this.props} />;
+      return <BaseComponent {...this.props} />;
     }
   }
 );


### PR DESCRIPTION
Slit this https://github.com/acdlite/recompose/pull/13
Also move props 2 defaultProps as React do