### PR TITLE
Avoid unnecessary intermediate elements by calling function components instead of using React.createElement()

### DIFF
--- a/src/branch.js
+++ b/src/branch.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import curry from 'lodash/function/curry';
 import wrapDisplayName from './wrapDisplayName';
+import createElement from './createElement';
 
 const branch = (test, left, right, BaseComponent) => (
   class extends React.Component {
@@ -29,7 +30,7 @@ const branch = (test, left, right, BaseComponent) => (
 
     render() {
       const { Component } = this;
-      return <Component {...this.props} />;
+      return createElement(Component, this.props);
     }
   }
 );

--- a/src/createElement.js
+++ b/src/createElement.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import isStatelessFunctionComponent from './isStatelessFunctionComponent';
+
+const createElement = (Component, props) => (
+  isStatelessFunctionComponent(Component)
+    ? /* eslint-disable */ Component(props) /* eslint-enable */
+    : <Component {...props} />
+);
+
+export default createElement;

--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -1,11 +1,9 @@
-import React from 'react';
 import curry from 'lodash/function/curry';
 import wrapDisplayName from './wrapDisplayName';
+import createElement from './createElement';
 
 const defaultProps = (props, BaseComponent) => {
-  const DefaultProps = ownerProps => (
-    <BaseComponent {...ownerProps} />
-  );
+  const DefaultProps = ownerProps => createElement(BaseComponent, ownerProps);
 
   DefaultProps.defaultProps = props;
   DefaultProps.displayName = wrapDisplayName(BaseComponent, 'defaultProps');

--- a/src/doOnReceiveProps.js
+++ b/src/doOnReceiveProps.js
@@ -1,11 +1,11 @@
-import React from 'react';
 import curry from 'lodash/function/curry';
 import wrapDisplayName from './wrapDisplayName';
+import createElement from './createElement';
 
 const doOnReceiveProps = (callback, BaseComponent) => {
   const DoOnReceiveProps = props => {
     callback(props);
-    return <BaseComponent {...props} />;
+    return createElement(BaseComponent, props);
   };
 
   DoOnReceiveProps.displayName = wrapDisplayName(

--- a/src/flattenProp.js
+++ b/src/flattenProp.js
@@ -1,14 +1,14 @@
-import React from 'react';
 import curry from 'lodash/function/curry';
 import omit from 'lodash/object/omit';
 import wrapDisplayName from './wrapDisplayName';
+import createElement from './createElement';
 
 const flattenProp = (propName, BaseComponent) => {
   const FlattenProps = props => (
-    <BaseComponent
-      {...omit(props, propName)}
-      {...props[propName]}
-    />
+    createElement(BaseComponent, {
+      ...omit(props, propName),
+      ...props[propName]
+    })
   );
 
   FlattenProps.displayName = wrapDisplayName(BaseComponent, 'flattenProp');

--- a/src/getContext.js
+++ b/src/getContext.js
@@ -1,16 +1,19 @@
-import React from 'react';
 import curry from 'lodash/function/curry';
 import wrapDisplayName from './wrapDisplayName';
+import createElement from './createElement';
 
-const getContext = (contextTypes, BaseComponent) => (
-  class extends React.Component {
-    static displayName = wrapDisplayName(BaseComponent, 'getContext');
-    static contextTypes = contextTypes;
+const getContext = (contextTypes, BaseComponent) => {
+  const GetContext = (ownerProps, context) => (
+    createElement(BaseComponent, {
+      ...ownerProps,
+      ...context
+    })
+  );
 
-    render() {
-      return <BaseComponent {...this.props} {...this.context} />;
-    }
-  }
-);
+  GetContext.displayName = wrapDisplayName(BaseComponent, 'getContext');
+  GetContext.contextTypes = contextTypes;
+
+  return GetContext;
+};
 
 export default curry(getContext);

--- a/src/isStatelessFunctionComponent.js
+++ b/src/isStatelessFunctionComponent.js
@@ -1,0 +1,6 @@
+const isStatelessFunctionComponent = Component => (
+  typeof Component !== 'string' &&
+  !('prototype' in Component)
+);
+
+export default isStatelessFunctionComponent;

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import curry from 'lodash/function/curry';
 import wrapDisplayName from './wrapDisplayName';
+import createElement from './createElement';
 
 const lifecycle = (setup, teardown, BaseComponent) => (
   class Lifecycle extends React.Component {
@@ -16,7 +17,10 @@ const lifecycle = (setup, teardown, BaseComponent) => (
     }
 
     render() {
-      return <BaseComponent {...this.props} {...this.state} />;
+      return createElement(BaseComponent, {
+        ...this.props,
+        ...this.state
+      });
     }
   }
 );

--- a/src/mapProps.js
+++ b/src/mapProps.js
@@ -1,9 +1,9 @@
-import React from 'react';
 import curry from 'lodash/function/curry';
 import wrapDisplayName from './wrapDisplayName';
+import createElement from './createElement';
 
 const mapProps = (propsMapper, BaseComponent) => {
-  const MapProps = props => <BaseComponent {...propsMapper(props)} />;
+  const MapProps = props => createElement(BaseComponent, propsMapper(props));
 
   MapProps.displayName = wrapDisplayName(BaseComponent, 'mapProps');
 

--- a/src/mapPropsOnUpdate.js
+++ b/src/mapPropsOnUpdate.js
@@ -1,13 +1,14 @@
-import React from 'react';
+import { Component } from 'react';
 import curry from 'lodash/function/curry';
 import wrapDisplayName from './wrapDisplayName';
 import shallowEqual from './shallowEqual';
 import pick from 'lodash/object/pick';
+import createElement from './createElement';
 
 const mapPropsOnUpdate = (depdendentPropKeys, propsMapper, BaseComponent) => {
   const pickDependentProps = props => pick(props, depdendentPropKeys);
 
-  return class extends React.Component {
+  return class extends Component {
     static displayName = wrapDisplayName(BaseComponent, 'mapPropsOnUpdate');
     childProps = propsMapper(this.props);
 
@@ -21,7 +22,7 @@ const mapPropsOnUpdate = (depdendentPropKeys, propsMapper, BaseComponent) => {
     }
 
     render() {
-      return <BaseComponent {...this.childProps} />;
+      return createElement(BaseComponent, this.childProps);
     }
   };
 };

--- a/src/shouldUpdate.js
+++ b/src/shouldUpdate.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import { Component } from 'react';
 import curry from 'lodash/function/curry';
 import wrapDisplayName from './wrapDisplayName';
+import createElement from './createElement';
 
 const shouldUpdate = (test, BaseComponent) => (
-  class extends React.Component {
+  class extends Component {
     static displayName = wrapDisplayName(BaseComponent, 'shouldUpdate');
 
     shouldComponentUpdate(nextProps) {
@@ -11,7 +12,7 @@ const shouldUpdate = (test, BaseComponent) => (
     }
 
     render() {
-      return <BaseComponent {...this.props} />;
+      return createElement(BaseComponent, this.props);
     }
   }
 );

--- a/src/withContext.js
+++ b/src/withContext.js
@@ -1,19 +1,20 @@
-import React from 'react';
+import { Component } from 'react';
 import curry from 'lodash/function/curry';
 import wrapDisplayName from './wrapDisplayName';
+import createElement from './createElement';
 
 const withContext = (
   childContextTypes,
   getChildContext,
   BaseComponent
 ) => (
-  class extends React.Component {
+  class extends Component {
     static displayName = wrapDisplayName(BaseComponent, 'withContext');
     static childContextTypes = childContextTypes;
     getChildContext = () => getChildContext(this.props);
 
     render() {
-      return <BaseComponent {...this.props} />;
+      return createElement(BaseComponent, this.props);
     }
   }
 );

--- a/src/withProps.js
+++ b/src/withProps.js
@@ -1,9 +1,14 @@
-import React from 'react';
 import curry from 'lodash/function/curry';
 import wrapDisplayName from './wrapDisplayName';
+import createElement from './createElement';
 
 const withProps = (props, BaseComponent) => {
-  const WithProps = ownerProps => <BaseComponent {...ownerProps} {...props} />;
+  const WithProps = ownerProps => (
+    createElement(BaseComponent, {
+      ...ownerProps,
+      ...props
+    })
+  );
 
   WithProps.displayName = wrapDisplayName(BaseComponent, 'withProps');
 

--- a/src/withReducer.js
+++ b/src/withReducer.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import { Component } from 'react';
 import curry from 'lodash/function/curry';
 import isFunction from 'lodash/lang/isFunction';
 import wrapDisplayName from './wrapDisplayName';
+import createElement from './createElement';
 
 const withReducer = (
   stateName,
@@ -10,7 +11,7 @@ const withReducer = (
   initialState,
   BaseComponent
 ) => (
-  class extends React.Component {
+  class extends Component {
     static displayName = wrapDisplayName(BaseComponent, 'withReducer');
 
     state = {
@@ -24,15 +25,11 @@ const withReducer = (
     }));
 
     render() {
-      return (
-        <BaseComponent
-          {...{
-            ...this.props,
-            [stateName]: this.state.stateValue,
-            [dispatchName]: this.dispatch
-          }}
-        />
-      );
+      return createElement(BaseComponent, {
+        ...this.props,
+        [stateName]: this.state.stateValue,
+        [dispatchName]: this.dispatch
+      });
     }
   }
 );

--- a/src/withState.js
+++ b/src/withState.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import { Component } from 'react';
 import curry from 'lodash/function/curry';
 import isFunction from 'lodash/lang/isFunction';
 import wrapDisplayName from './wrapDisplayName';
+import createElement from './createElement';
 
 export const withState = (
   stateName,
@@ -9,7 +10,7 @@ export const withState = (
   initialState,
   BaseComponent
 ) => (
-  class extends React.Component {
+  class extends Component {
     static displayName = wrapDisplayName(BaseComponent, 'withState');
     state = {
       stateValue: isFunction(initialState)
@@ -24,12 +25,11 @@ export const withState = (
     )
 
     render() {
-      const childProps = {
+      return createElement(BaseComponent, {
         ...this.props,
         [stateName]: this.state.stateValue,
         [stateUpdaterName]: this.updateStateValue
-      };
-      return <BaseComponent {...childProps}/>;
+      });
     }
   }
 );


### PR DESCRIPTION
Adds a replacement for `React.createElement(Component, props)` which checks if the component is a stateless function. If so, it calls the function rather than creating an intermediate React element, hashtag referential transparency.

Used internally, but not exposed publicly since React will presumably optimize for stateless function components soon.