### PR TITLE
Components that use propTypes are not referentially transparent

### DIFF
--- a/src/__tests__/isReferentiallyTransparentFunctionComponent-test.js
+++ b/src/__tests__/isReferentiallyTransparentFunctionComponent-test.js
@@ -44,4 +44,11 @@ describe('isReferentiallyTransparentFunctionComponent()', () => {
 
     expect(isReferentiallyTransparentFunctionComponent(Foo)).to.be.false;
   });
+
+  it('returns false for functions that use propTypes', () => {
+    const Foo = (props, context) => <div {...props} {...context} />;
+    Foo.propTypes = { store: PropTypes.object };
+
+    expect(isReferentiallyTransparentFunctionComponent(Foo)).to.be.false;
+  });
 });

--- a/src/isReferentiallyTransparentFunctionComponent.js
+++ b/src/isReferentiallyTransparentFunctionComponent.js
@@ -3,7 +3,8 @@ const isReferentiallyTransparentFunctionComponent = Component => (
   typeof Component !== 'string' &&
   !(Component.prototype && Component.prototype.render) &&
   !Component.defaultProps &&
-  !Component.contextTypes
+  !Component.contextTypes &&
+  !Component.propTypes
 );
 
 export default isReferentiallyTransparentFunctionComponent;


### PR DESCRIPTION
Updates `isReferentiallyTransparentFunctionComponent()` to check for `propTypes`.