### PR TITLE
Static property helpers

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -9,8 +9,7 @@ type HigherOrderComponent = (BaseComponent: ReactElementType) => ReactElementTyp
 ```
 For the purposes of typing, a higher-order component is a function that accepts a base React component and returns a new React component. However, sometimes we use the term higher-order component to refer to a function that takes one or more parameters in addition to a base component. For example, `mapProps()` takes both a props mapping function and a base component. Higher-order components helpers in Recompose are component-last and curried, so when we call a helper with all its parameters except the final one, it returns a "true" higher-order component. The distinction isn't all that important in most cases except for type signatures; just be aware that it exists.
 
-## Higher-order component helper
-
+## Higher-order component helpers
 
 Higher-order component helpers are automatically curried, and the final parameter is a React component class.
 
@@ -347,6 +346,44 @@ Provides access to the React component instance on initialization (setup) and un
 `setup` is called within the component's constructor, so you can set the initial state using assignment as in a normal React component class. After initialization ,calls to `component.setState()` will update the state as expected.
 
 The state object is mixed into the props and passed to the base component.
+
+## Static property helpers
+
+These functions look like higher-order component helpers — they are curried and component-last. However, rather than returning a new component, they mutate the base component by setting or overriding a static property.
+
+### `setStatic()`
+
+```js
+setStatic(
+  key: string,
+  value: any,
+  BaseComponent: ReactElementType
+): ReactElementType
+```
+
+Assigns a value to a static property on the base component.
+
+### `setPropTypes()`
+
+```js
+setPropTypes(
+  propTypes: Object,
+  BaseComponent: ReactElementType
+): ReactElementType
+```
+
+Assigns to the `propTypes` property on the base component.
+
+### `setDisplayName()`
+
+```js
+setDisplayName(
+  propTypes: string,
+  BaseComponent: ReactElementType
+): ReactElementType
+```
+
+Assigns to the `displayName` property on the base component.
 
 ## Utilities
 

--- a/src/__tests__/setDisplayName-test.js
+++ b/src/__tests__/setDisplayName-test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { expect } from 'chai';
+import { setDisplayName } from 'recompose';
+
+describe('setDisplayName()', () => {
+  it('sets a static property on the base component', () => {
+    const BaseComponent = () => <div />;
+    const NewComponent = setDisplayName('Foo', BaseComponent);
+
+    expect(NewComponent.displayName).to.eql('Foo');
+  });
+});

--- a/src/__tests__/setPropTypes-test.js
+++ b/src/__tests__/setPropTypes-test.js
@@ -1,0 +1,17 @@
+import React, { PropTypes } from 'react';
+import { expect } from 'chai';
+import { setPropTypes } from 'recompose';
+
+describe('setPropTypes()', () => {
+  it('sets a static property on the base component', () => {
+    const BaseComponent = () => <div />;
+    const NewComponent = setPropTypes(
+      { foo: PropTypes.object },
+      BaseComponent
+    );
+
+    expect(NewComponent.propTypes).to.eql({
+      foo: PropTypes.object
+    });
+  });
+});

--- a/src/__tests__/setStatic-test.js
+++ b/src/__tests__/setStatic-test.js
@@ -1,0 +1,18 @@
+import React, { PropTypes } from 'react';
+import { expect } from 'chai';
+import { setStatic } from 'recompose';
+
+describe('setStatic()', () => {
+  it('sets a static property on the base component', () => {
+    const BaseComponent = () => <div />;
+    const NewComponent = setStatic(
+      'propTypes',
+      { foo: PropTypes.object },
+      BaseComponent
+    );
+
+    expect(NewComponent.propTypes).to.eql({
+      foo: PropTypes.object
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,13 @@ export lifecycle from './lifecycle';
 
 // Static property helpers
 export setStatic from './setStatic';
+export setPropTypes from './setPropTypes';
+export setDisplayName from './setDisplayName';
 
+// Composition function
 export compose from 'lodash/function/compose';
 
-// Other helpers
+// Other utils
 export getDisplayName from './getDisplayName';
 export wrapDisplayName from './wrapDisplayName';
 export shallowEqual from './shallowEqual';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+// Higher-order component helpers
 export mapProps from './mapProps';
 export mapPropsOnUpdate from './mapPropsOnUpdate';
 export withProps from './withProps';
@@ -18,10 +19,13 @@ export getContext from './getContext';
 export doOnReceiveProps from './doOnReceiveProps';
 export lifecycle from './lifecycle';
 
+// Static property helpers
+export setStatic from './setStatic';
+
 export compose from 'lodash/function/compose';
 
+// Other helpers
 export getDisplayName from './getDisplayName';
 export wrapDisplayName from './wrapDisplayName';
 export shallowEqual from './shallowEqual';
-
 export createSink from './createSink';

--- a/src/setDisplayName.js
+++ b/src/setDisplayName.js
@@ -1,0 +1,5 @@
+import setStatic from './setStatic';
+
+const setPropTypes = setStatic('displayName');
+
+export default setPropTypes;

--- a/src/setPropTypes.js
+++ b/src/setPropTypes.js
@@ -1,0 +1,5 @@
+import setStatic from './setStatic';
+
+const setPropTypes = setStatic('propTypes');
+
+export default setPropTypes;

--- a/src/setStatic.js
+++ b/src/setStatic.js
@@ -1,0 +1,8 @@
+import curry from 'lodash/function/curry';
+
+const setStatic = (key, value, BaseComponent) => {
+  BaseComponent[key] = value;
+  return BaseComponent;
+};
+
+export default curry(setStatic);


### PR DESCRIPTION
Adds some static property helpers that look like higher-order component helpers (curried and component-last) but are used to mutate the base component rather than return a new component.

- `setStatic()`
- `setPropTypes()`
- `setDisplayName()`