### PR TITLE
New package: rx-recompose

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Here's an example of a stateful counter component created using only pure functi
 import { compose, withState, mapProps } from 'recompose';
 
 const Counter = ({ counter, increment, decrement }) => (
-  <p>
+  <div>
     Count: {counter}
     <button onClick={increment}>+</button>
     <button onClick={decrement}>-</button>
-  </p>
+  </div>
 );
 
 const CounterContainer = compose(

--- a/src/packages/rx-recompose/README.md
+++ b/src/packages/rx-recompose/README.md
@@ -1,0 +1,76 @@
+rx-recompose
+============
+
+[![npm version](https://img.shields.io/npm/v/recompose-relay.svg?style=flat-square)](https://www.npmjs.com/package/rx-recompose)
+
+[RxJS](https://github.com/ReactiveX/RxJS) utilities for [Recompose](https://github.com/acdlite/recompose).
+
+
+## API
+
+### `observeProps()`
+
+```js
+observeProps(
+  mapPropsStream: (props$: Observable) => Observable,
+  BaseComponent: ReactElementType
+): ReactElementType
+```
+
+Maps an observable stream of owner props to a stream of child props.
+
+It turns out that much of the React Component API can be expressed in terms of observables:
+
+- Instead of `setState()`, combine multiple streams together.
+- Instead of `getIntialState()`, use `startWith()`.
+- Instead of `shouldComponentUpdate()`, use `distinctUntilChanged()`, `debounce()`, etc.
+
+Other benefits include:
+
+- No distinction between state and props – everything is an stream.
+- No need to worry about unsubscribing from event listeners. Subscriptions are handled for you.
+- Sideways data loading is trivial – just combine the props stream with an external stream.
+- Access to the full ecosystem of RxJS libraries.
+
+(Examples to come.)
+
+### `createEventHandler()`
+
+```js
+createEventHandler(): Function & Subject
+```
+
+Creates a Subject that is also a function. When called, the subject emits a new value. This type of function is ideal for passing event handlers from `observeProps()`:
+
+```js
+const Counter = mapProps(
+  props$ => {
+    const increment$ = createEventHandler();
+    const decrement$ = createEventHandler();
+
+    const count$ = Observable.merge(
+        increment$.map(() => 1),
+        decrement$.map(() => -1)
+      )
+      .startWith(0)
+      .scan((count, n) => count + n);
+
+    return Observable.combineLatest(
+      props$, count$,
+      (props, count) => ({
+        increment: increment$,
+        decrement: decrement$,
+        count,
+        ...props
+      })
+    );
+  },
+  ({ count, increment, ...props }) => {
+    <div {...props}>
+      Count: {counter}
+      <button onClick={increment}>+</button>
+      <button onClick={decrement}>-</button>
+    </div>
+  }
+);
+```

--- a/src/packages/rx-recompose/__tests__/createEventHandler-test.js
+++ b/src/packages/rx-recompose/__tests__/createEventHandler-test.js
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { createEventHandler } from 'rx-recompose';
+
+describe('createEventHandler()', () => {
+  it('creates a subject that broadcasts new values when called as a function', () => {
+    const result = [];
+    const eventHandler = createEventHandler();
+    const subscription = eventHandler.subscribe(v => result.push(v));
+
+    eventHandler(1);
+    eventHandler(2);
+    eventHandler(3);
+
+    subscription.dispose();
+    expect(result).to.eql([1, 2, 3]);
+  });
+});

--- a/src/packages/rx-recompose/__tests__/observeProps-test.js
+++ b/src/packages/rx-recompose/__tests__/observeProps-test.js
@@ -1,0 +1,77 @@
+import { expect } from 'chai';
+import React from 'react';
+import { Observable } from 'rx';
+import { toClass, withState } from 'recompose';
+import createSpy from 'recompose/createSpy';
+import { observeProps, createEventHandler } from 'rx-recompose';
+
+import {
+  Simulate,
+  renderIntoDocument,
+  findRenderedDOMComponentWithTag,
+  findRenderedComponentWithType,
+  createRenderer
+} from 'react-addons-test-utils';
+
+const createSmartButton = BaseComponent => (
+  observeProps(props$ => {
+    const increment$ = createEventHandler();
+    const count$ = increment$
+      .startWith(0)
+      .scan(total => total + 1);
+
+    return Observable.combineLatest(props$, count$, (props, count) => ({
+      ...props,
+      onClick: increment$,
+      count
+    }));
+  }, toClass(BaseComponent))
+);
+
+
+const Button = toClass(props => <button {...props} />);
+
+function testSmartButton(element) {
+  const tree = renderIntoDocument(element);
+  const button = findRenderedComponentWithType(tree, Button);
+  const buttonNode = findRenderedDOMComponentWithTag(tree, 'button');
+
+  Simulate.click(buttonNode);
+  Simulate.click(buttonNode);
+  Simulate.click(buttonNode);
+
+  expect(button.props.count).to.equal(3);
+  expect(button.props.pass).to.equal('through');
+}
+
+describe('observeProps', () => {
+  it('maps a stream of owner props to a stream of child props', () => {
+    const SmartButton = createSmartButton(props => <Button {...props} />);
+    expect(SmartButton.displayName).to.equal('observeProps(Component)');
+    testSmartButton(<SmartButton pass="through" />);
+  });
+
+  it('works on initial render', () => {
+    const SmartButton = createSmartButton(props => <Button {...props} />);
+
+    // Test using shallow renderer, which only renders once
+    const renderer = createRenderer();
+    renderer.render(<SmartButton pass="through" />);
+    const button = renderer.getRenderOutput();
+    expect(button.props.pass).to.equal('through');
+    expect(button.props.count).to.equal(0);
+  });
+
+  it('receives prop updates', () => {
+    const spy = createSpy();
+    const SmartButton = createSmartButton(spy('div'));
+
+    const Container = withState('label', 'updateLabel', 'Count', SmartButton);
+
+    renderIntoDocument(<Container />);
+
+    expect(spy.getProps().label).to.equal('Count');
+    spy.getProps().updateLabel('Current count');
+    expect(spy.getProps().label).to.equal('Current count');
+  });
+});

--- a/src/packages/rx-recompose/createEventHandler.js
+++ b/src/packages/rx-recompose/createEventHandler.js
@@ -1,0 +1,21 @@
+import { Subject } from 'rx';
+
+// Idea and implementation borrowed from
+// https://github.com/fdecampredon/rx-react
+const createEventHandler = () => {
+  function subject(value) {
+    subject.onNext(value);
+  }
+
+  /* eslint-disable */
+  for (let key in Subject.prototype) {
+  /* eslint-enable */
+    subject[key] = Subject.prototype[key];
+  }
+
+  Subject.call(subject);
+
+  return subject;
+};
+
+export default createEventHandler;

--- a/src/packages/rx-recompose/index.js
+++ b/src/packages/rx-recompose/index.js
@@ -1,0 +1,2 @@
+export observeProps from './observeProps';
+export createEventHandler from './createEventHandler';

--- a/src/packages/rx-recompose/observeProps.js
+++ b/src/packages/rx-recompose/observeProps.js
@@ -1,0 +1,56 @@
+import { Component } from 'react';
+import curry from 'lodash/function/curry';
+import createElement from 'recompose/createElement';
+import wrapDisplayName from 'recompose/wrapDisplayName';
+import { Subject } from 'rx';
+
+const observeProps = (propsSequenceMapper, BaseComponent) => (
+  class extends Component {
+    static displayName = wrapDisplayName(BaseComponent, 'observeProps');
+
+    state = {};
+
+    // Subject that receives props from owner
+    ownerProps$ = new Subject();
+
+    // Sequence of child props
+    childProps$ = propsSequenceMapper(this.ownerProps$.startWith(this.props));
+
+    // Keep track of whether the component has mounted
+    componentHasMounted = false;
+
+    componentWillMount() {
+      // Subscribe to child prop changes so we know when to re-render
+      this.subscription = this.childProps$.subscribe(
+        childProps =>
+          !this.componentHasMounted
+            ? this.state = { childProps }
+            : this.setState({ childProps })
+      );
+    }
+
+    componentDidMount() {
+      this.componentHasMounted = true;
+    }
+
+    componentWillReceiveProps(nextProps) {
+      // Receive new props from the owner
+      this.ownerProps$.onNext(nextProps);
+    }
+
+    shouldComponentUpdate(nextProps, nextState) {
+      return nextState.childProps !== this.state.childProps;
+    }
+
+    componentWillUnmount() {
+      // Clean-up subscription before un-mounting
+      this.subscription.dispose();
+    }
+
+    render() {
+      return createElement(BaseComponent, this.state.childProps);
+    }
+  }
+);
+
+export default curry(observeProps);

--- a/src/packages/rx-recompose/package.json
+++ b/src/packages/rx-recompose/package.json
@@ -1,0 +1,28 @@
+{
+  "description": "RxJS utilities for React and Recompose.",
+  "keywords": [
+    "recompose",
+    "rxjs",
+    "rx",
+    "react",
+    "observable",
+    "reactive",
+    "higher-order",
+    "components",
+    "microcomponentization",
+    "toolkit",
+    "utilities",
+    "composition"
+  ],
+  "dependencies": {
+    "lodash": "^3.0.0"
+  },
+  "peerDependencies": {
+    "recompose": "^0.8.0",
+    "react": "^0.14.0",
+    "rx": "^4.0.0"
+  },
+  "devDependencies": {
+    "rx": "^4.0.0"
+  }
+}


### PR DESCRIPTION
RxJS bindings for Recompose and React.

Includes a helper called `observeProps()`. Very similar to `mapProps()`—instead of mapping owner props to child props, it maps a *sequence* of owner props to a sequence of child props.

```js
observeProps($ownerProps => $childProps)
```

Also includes `createEventHandler()`, which is a shortcut for creating a subject that pushes new values whenever it is called as a function.

This is essentially a port of my [react-rx-component](https://github.com/acdlite/react-rx-component) project, which I will deprecate in favor of this.