### PR TITLE
New util: componentFromProp()

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -479,3 +479,24 @@ createSink(callback: (props: Object) => void): ReactElementType
 ```
 
 Creates a component that renders nothing (null) but calls a callback when receiving new props.
+
+### `componentFromProp()`
+
+```js
+componentFromProp(propName: string): ReactElementType
+```
+
+Creates a component that accepts a component as a prop and renders it with the remaining props.
+
+Example:
+
+```js
+const Button = defaultProps(
+  { component: 'button' },
+  componentFromProp('component')
+);
+
+<Button foo="bar" /> // renders <button foo="bar" />
+<Button component="a" foo="bar" />  // renders <a foo="bar" />
+<Button component={Link} foo="bar" />  // renders <Link foo="bar" />
+```

--- a/src/packages/recompose/__tests__/componentFromProp-test.js
+++ b/src/packages/recompose/__tests__/componentFromProp-test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { expect } from 'chai';
+import { componentFromProp } from 'recompose';
+import createSpy from 'recompose/createSpy';
+
+import { renderIntoDocument } from 'react-addons-test-utils';
+
+describe('componentFromProp()', () => {
+  it('returns a component takes a component as a prop and renders it with the rest of the props', () => {
+    const spy = createSpy();
+    const Spy = spy('div');
+    const SpyContainer = componentFromProp('component');
+
+    expect(SpyContainer.displayName).to.equal('componentFromProp(component)');
+
+    renderIntoDocument(<SpyContainer component={Spy} pass="through" />);
+
+    expect(spy.getProps()).to.eql({ pass: 'through' });
+  });
+});

--- a/src/packages/recompose/__tests__/createSpy-test.js
+++ b/src/packages/recompose/__tests__/createSpy-test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { expect } from 'chai';
 import { compose, withState, branch } from 'recompose';
 import createSpy from 'recompose/createSpy';
@@ -96,6 +96,10 @@ describe('createSpy', () => {
       it('gets a ref to the spied component for a given index', () => {
         const spy = createSpy();
         const Spy = spy(class extends React.Component {
+          static propTypes = {
+            n: PropTypes.number
+          };
+
           n = this.props.n;
 
           render() {

--- a/src/packages/recompose/componentFromProp.js
+++ b/src/packages/recompose/componentFromProp.js
@@ -1,0 +1,18 @@
+import wrapDisplayName from './wrapDisplayName';
+import omit from 'lodash/object/omit';
+import createElement from './createElement';
+
+const componentFromProp = propName => {
+  const ComponentFromProp = props => (
+    createElement(props[propName], omit(props, propName))
+  );
+
+  ComponentFromProp.displayName = wrapDisplayName(
+    propName,
+    'componentFromProp'
+  );
+
+  return ComponentFromProp;
+};
+
+export default componentFromProp;

--- a/src/packages/recompose/index.js
+++ b/src/packages/recompose/index.js
@@ -35,3 +35,4 @@ export wrapDisplayName from './wrapDisplayName';
 export shallowEqual from './shallowEqual';
 export isClassComponent from './isClassComponent';
 export createSink from './createSink';
+export componentFromProp from './componentFromProp';


### PR DESCRIPTION

```js
componentFromProp(propName: string): ReactElementType
```

Creates a component that accepts a component as a prop and renders it with the remaining props.

Example:

```js
const Button = defaultProps(
  { component: 'button' },
  componentFromProp('component')
);

<Button foo="bar" /> // renders <button foo="bar" />
<Button component="a" foo="bar" />  // renders <a foo="bar" />
<Button component={Link} foo="bar" />  // renders <Link foo="bar" />
```