### PR TITLE
correct renderComponent() example

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -214,9 +214,9 @@ This is useful in combination with another helper that expects a higher-order co
 // has all the props it needs
 const spinnerWhileLoading = (hasLoaded, BaseComponent) => branch(
   hasLoaded,
-  BaseComponent,
+  renderComponent(BaseComponent),
   renderComponent(Spinner) // <Spinner> is a React component
-);
+)(renderNothing());
 
 // Now use the `spinnerWhileLoading()` helper to add a loading spinner to any
 // base component


### PR DESCRIPTION
Since the second argument of `branch` should be a HoC, I've wrapped `BaseComponent` inside a HoC using `renderComponent`.

Also, if `Post` is to be a component, then the curried `branch` function needs to be invoked with a component. In the example, I've used `renderNothing()` as this component.

However, using `branch` like this kinda of feels hacky--especially with using `renderNothing()` as its BaseComponent--but it does produce the desired effect of the `conditional()` mentioned in issue #21.