### PR TITLE
Helpful warnings in development

### DIFF
--- a/src/packages/recompose-relay/createContainer.js
+++ b/src/packages/recompose-relay/createContainer.js
@@ -2,8 +2,8 @@ import Relay from 'react-relay'
 import curry from 'lodash/function/curry'
 import toClass from 'recompose/toClass'
 
-const createContainer = curry((options, BaseComponent) => (
+const createContainer = (options, BaseComponent) => (
   Relay.createContainer(toClass(BaseComponent), options)
-))
+)
 
-export default createContainer
+export default curry(createContainer)

--- a/src/packages/recompose-relay/createContainer.js
+++ b/src/packages/recompose-relay/createContainer.js
@@ -1,9 +1,9 @@
 import Relay from 'react-relay'
-import curry from 'lodash/function/curry'
 import toClass from 'recompose/toClass'
+import createHelper from 'recompose/createHelper'
 
 const createContainer = (options, BaseComponent) => (
   Relay.createContainer(toClass(BaseComponent), options)
 )
 
-export default curry(createContainer)
+export default createHelper(createContainer, 'createContainer', null, false)

--- a/src/packages/recompose/__tests__/compose-test.js
+++ b/src/packages/recompose/__tests__/compose-test.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { expect } from 'chai'
+import { compose, mapProps, setDisplayName } from 'recompose'
+import identity from 'lodash/utility/identity'
+
+describe('compose()', () => {
+  const BaseComponent = setDisplayName('BaseComponent', () => <div />)
+
+  it('warns if higher-order component helper has too few arguments applied', () => {
+    const error = sinon.stub(console, 'error')
+
+    compose(
+      mapProps(),
+      mapProps(identity)
+    )(BaseComponent)
+
+    expect(error.callCount).to.equal(1)
+    expect(error.firstCall.args[0]).to.equal(
+      'Attempted to compose `mapProps()` with other higher-order component ' +
+      'helpers, but it has been applied with 1 too few parameters. Check the ' +
+      'implementation of <BaseComponent>.'
+    )
+
+    /* eslint-disable */
+    console.error.restore()
+    /* eslint-enable */
+  })
+
+  it('does not warn if helper is under-applied, but none of the other functions are applied helpers', () => {
+    const error = sinon.stub(console, 'error')
+
+    compose(
+      mapProps(),
+      identity
+    )(BaseComponent)
+
+    expect(error.callCount).to.equal(0)
+
+    /* eslint-disable */
+    console.error.restore()
+    /* eslint-enable */
+  })
+})

--- a/src/packages/recompose/__tests__/createHelper-test.js
+++ b/src/packages/recompose/__tests__/createHelper-test.js
@@ -1,0 +1,45 @@
+import { expect } from 'chai'
+import createHelper from '../createHelper'
+import lodashCurry from 'lodash/function/curry'
+
+describe('createHelper()', () => {
+  const func = (a, b, c) => ({ a, b, c })
+
+  const a = { displayName: 'a' }
+  const b = { displayName: 'b' }
+  const c = { displayName: 'c' }
+
+  it('works like lodash\'s curry', () => {
+    const helper1 = createHelper(func)
+    const helper2 = lodashCurry(func)
+
+    const testEqualOutput = callback => {
+      const result1 = callback(helper1)
+      const result2 = callback(helper2)
+
+      expect(result1.a).to.equal(result2.a)
+      expect(result1.b).to.equal(result2.b)
+      expect(result1.c).to.equal(result2.c)
+    }
+
+    testEqualOutput(helper => helper(a, b, c))
+    testEqualOutput(helper => helper(a)(b)(c))
+    testEqualOutput(helper => helper()(a, b, c))
+    testEqualOutput(helper => helper(null)(b, c))
+    testEqualOutput(helper => helper(undefined)(b, c))
+  })
+
+  it('properly sets display name', () => {
+    expect(
+      createHelper(func, 'func')(a, b, c).displayName
+    ).to.equal('func(c)')
+
+    expect(
+      createHelper(func, 'func', null, false)(a, b, c).displayName
+    ).to.be.undefined
+
+    expect(
+      createHelper(func, null, null, true)(a, b, c).displayName
+    ).to.be.undefined
+  })
+})

--- a/src/packages/recompose/__tests__/onlyUpdateForPropTypes-test.js
+++ b/src/packages/recompose/__tests__/onlyUpdateForPropTypes-test.js
@@ -55,20 +55,20 @@ describe('onlyUpdateForPropTypes()', () => {
   })
 
   it('warns if BaseComponent does not have any propTypes', () => {
-    const warn = sinon.spy(console, 'warn')
+    const error = sinon.stub(console, 'error')
 
     const ShouldWarn = onlyUpdateForPropTypes('div')
 
     renderIntoDocument(<ShouldWarn />)
 
-    expect(warn.firstCall.args[0]).to.equal(
+    expect(error.firstCall.args[0]).to.equal(
       'A component without any `propTypes` was passed to ' +
       '`onlyUpdateForPropTypes()`. Check the implementation of the component ' +
       'with display name "div".'
     )
 
     /* eslint-disable */
-    console.warn.restore()
+    console.error.restore()
     /* eslint-enable */
   })
 })

--- a/src/packages/recompose/__tests__/renderNothing-test.js
+++ b/src/packages/recompose/__tests__/renderNothing-test.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai'
 import { renderNothing } from 'recompose'
 
-describe('mapProps()', () => {
-  it('maps owner props to child props', () => {
+describe('renderNothing()', () => {
+  it('returns a component that renders null', () => {
     const Nothing = renderNothing('div')
     const n = Nothing
     expect(n()).to.be.null

--- a/src/packages/recompose/branch.js
+++ b/src/packages/recompose/branch.js
@@ -1,11 +1,9 @@
 import React from 'react'
-import curry from 'lodash/function/curry'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
-const branch = (test, left, right, BaseComponent) => (
+const branch = (test, left, right, BaseComponent) =>
   class extends React.Component {
-    static displayName = wrapDisplayName(BaseComponent, 'branch')
     LeftComponent = null
     RightComponent = null
 
@@ -33,6 +31,5 @@ const branch = (test, left, right, BaseComponent) => (
       return createElement(Component, this.props)
     }
   }
-)
 
-export default curry(branch)
+export default createHelper(branch, 'branch')

--- a/src/packages/recompose/componentFromProp.js
+++ b/src/packages/recompose/componentFromProp.js
@@ -1,18 +1,8 @@
-import wrapDisplayName from './wrapDisplayName'
 import omit from 'lodash/object/omit'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
-const componentFromProp = propName => {
-  const ComponentFromProp = props => (
-    createElement(props[propName], omit(props, propName))
-  )
+const componentFromProp = propName =>
+  props => createElement(props[propName], omit(props, propName))
 
-  ComponentFromProp.displayName = wrapDisplayName(
-    propName,
-    'componentFromProp'
-  )
-
-  return ComponentFromProp
-}
-
-export default componentFromProp
+export default createHelper(componentFromProp, 'componentFromProp')

--- a/src/packages/recompose/compose.js
+++ b/src/packages/recompose/compose.js
@@ -1,1 +1,59 @@
-export default from 'lodash/function/compose'
+import lodashCompose from 'lodash/function/compose'
+
+/**
+ * In production, use lodash's compose
+ */
+let compose = lodashCompose
+
+/**
+ * In development, print warnings when composing higher-order component helpers
+ * that have been applied with too few parameters
+ */
+if (process.env.NODE_ENV !== 'production') {
+  const getDisplayName = require('./getDisplayName')
+
+  compose = (...funcs) => {
+    const needsParameters = []
+    const doesntNeedParameters = []
+
+    funcs.forEach(func => {
+      const missingHelperParameters = func.__missingHelperParameters
+      if (missingHelperParameters === 0) {
+        doesntNeedParameters.push(func)
+      } else if (missingHelperParameters > 0) {
+        needsParameters.push(func)
+      }
+    })
+
+    /**
+     * Warn if a helper that needs parameters is composed with another helper
+     * that doesn't need parameters. Checking for the second condition allows
+     * partially-applied helpers to be composed before they become
+     * higher-order components.
+     */
+    if (needsParameters.length && doesntNeedParameters.length) {
+      return BaseComponent => {
+        const displayName = getDisplayName(BaseComponent)
+
+        needsParameters.forEach(func => {
+          const helperName = func.__helperName
+          const amountMissing = func.__missingHelperParameters
+          /* eslint-disable */
+          console.error(
+          /* eslint-enable */
+            `Attempted to compose \`${helperName}()\` with other ` +
+            'higher-order component helpers, but it has been applied with ' +
+            `${amountMissing} too few parameters. Check the implementation ` +
+            `of <${displayName}>.`
+          )
+        })
+
+        return lodashCompose(...funcs)(BaseComponent)
+      }
+    }
+
+    return lodashCompose(...funcs)
+  }
+}
+
+export default compose

--- a/src/packages/recompose/createHelper.js
+++ b/src/packages/recompose/createHelper.js
@@ -1,0 +1,51 @@
+import curry from 'lodash/function/curry'
+
+/**
+ * In production, use lodash's curry and be done
+ */
+let createHelper = curry
+
+/**
+ * In development, use custom implementation of curry that keeps track
+ * of whether enough parameters have been applied. Also adds a `displayName`
+ * to the base commponent.
+ */
+if (process.env.NODE_ENV !== 'production') {
+  const wrapDisplayName = require('./wrapDisplayName')
+
+  createHelper = (func, helperName, _helperLength, setDisplayName = true) => {
+    const helperLength = _helperLength || func.length
+
+    const apply = (previousArgs, nextArgs) => {
+      const args = previousArgs.concat(nextArgs)
+      const argsLength = args.length
+
+      if (argsLength < helperLength) {
+        const partialFunc = (...partialArgs) => apply(args, partialArgs)
+
+        /**
+         * The development version of `compose` will use these properties to
+         * print warnings
+         */
+        partialFunc.__missingHelperParameters = helperLength - argsLength - 1
+        partialFunc.__helperName = helperName
+
+        return partialFunc
+      }
+
+      const BaseComponent = args[helperLength - 1]
+
+      const Component = func(...args)
+
+      if (helperName && setDisplayName) {
+        Component.displayName = wrapDisplayName(BaseComponent, helperName)
+      }
+
+      return Component
+    }
+
+    return (...args) => apply([], args)
+  }
+}
+
+export default createHelper

--- a/src/packages/recompose/createSink.js
+++ b/src/packages/recompose/createSink.js
@@ -1,12 +1,9 @@
 import React from 'react'
 
-const createSink = callback => {
-  const Sink = props => {
+const createSink = callback =>
+  props => {
     callback(props)
     return <div />
   }
-
-  return Sink
-}
 
 export default createSink

--- a/src/packages/recompose/createSpy.js
+++ b/src/packages/recompose/createSpy.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 
 const createSpy = () => {
   let spyInfo = []
@@ -32,9 +32,7 @@ const createSpy = () => {
     info.component = component
   }
 
-  const spy = BaseComponent => class extends React.Component {
-    static displayName = wrapDisplayName(BaseComponent, 'spy')
-
+  const spy = createHelper(BaseComponent => class extends React.Component {
     constructor(props, context) {
       super(props, context)
       addSpyInstance(this)
@@ -54,7 +52,7 @@ const createSpy = () => {
     render() {
       return <BaseComponent {...this.props} ref={this.refCallback} />
     }
-  }
+  }, 'spy')
 
   spy.getInfo = () => spyInfo
   spy.getProps = (componentIndex = 0, renderIndex = 0) => (

--- a/src/packages/recompose/defaultProps.js
+++ b/src/packages/recompose/defaultProps.js
@@ -1,14 +1,10 @@
-import curry from 'lodash/function/curry'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
 const defaultProps = (props, BaseComponent) => {
   const DefaultProps = ownerProps => createElement(BaseComponent, ownerProps)
-
   DefaultProps.defaultProps = props
-  DefaultProps.displayName = wrapDisplayName(BaseComponent, 'defaultProps')
-
   return DefaultProps
 }
 
-export default curry(defaultProps)
+export default createHelper(defaultProps, 'defaultProps')

--- a/src/packages/recompose/doOnReceiveProps.js
+++ b/src/packages/recompose/doOnReceiveProps.js
@@ -1,19 +1,10 @@
-import curry from 'lodash/function/curry'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
-const doOnReceiveProps = (callback, BaseComponent) => {
-  const DoOnReceiveProps = props => {
+const doOnReceiveProps = (callback, BaseComponent) =>
+  props => {
     callback(props)
     return createElement(BaseComponent, props)
   }
 
-  DoOnReceiveProps.displayName = wrapDisplayName(
-    BaseComponent,
-    'doOnReceiveProps'
-  )
-
-  return DoOnReceiveProps
-}
-
-export default curry(doOnReceiveProps)
+export default createHelper(doOnReceiveProps, 'doOnReceiveProps')

--- a/src/packages/recompose/flattenProp.js
+++ b/src/packages/recompose/flattenProp.js
@@ -1,19 +1,13 @@
-import curry from 'lodash/function/curry'
 import omit from 'lodash/object/omit'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
-const flattenProp = (propName, BaseComponent) => {
-  const FlattenProps = props => (
+const flattenProp = (propName, BaseComponent) =>
+  props => (
     createElement(BaseComponent, {
       ...omit(props, propName),
       ...props[propName]
     })
   )
 
-  FlattenProps.displayName = wrapDisplayName(BaseComponent, 'flattenProp')
-
-  return FlattenProps
-}
-
-export default curry(flattenProp)
+export default createHelper(flattenProp, 'flattenProp')

--- a/src/packages/recompose/getContext.js
+++ b/src/packages/recompose/getContext.js
@@ -1,5 +1,4 @@
-import curry from 'lodash/function/curry'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
 const getContext = (contextTypes, BaseComponent) => {
@@ -10,10 +9,9 @@ const getContext = (contextTypes, BaseComponent) => {
     })
   )
 
-  GetContext.displayName = wrapDisplayName(BaseComponent, 'getContext')
   GetContext.contextTypes = contextTypes
 
   return GetContext
 }
 
-export default curry(getContext)
+export default createHelper(getContext, 'getContext')

--- a/src/packages/recompose/index.js
+++ b/src/packages/recompose/index.js
@@ -27,7 +27,7 @@ export setPropTypes from './setPropTypes'
 export setDisplayName from './setDisplayName'
 
 // Composition function
-export compose from 'lodash/function/compose'
+export compose from './compose'
 
 // Other utils
 export getDisplayName from './getDisplayName'

--- a/src/packages/recompose/lifecycle.js
+++ b/src/packages/recompose/lifecycle.js
@@ -1,12 +1,9 @@
 import React from 'react'
-import curry from 'lodash/function/curry'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
 const lifecycle = (setup, teardown, BaseComponent) => (
   class Lifecycle extends React.Component {
-    static displayName = wrapDisplayName(BaseComponent, 'lifecycle')
-
     constructor(props, context) {
       super(props, context)
       setup(this)
@@ -25,4 +22,4 @@ const lifecycle = (setup, teardown, BaseComponent) => (
   }
 )
 
-export default curry(lifecycle)
+export default createHelper(lifecycle, 'lifecycle')

--- a/src/packages/recompose/mapProps.js
+++ b/src/packages/recompose/mapProps.js
@@ -1,13 +1,7 @@
-import curry from 'lodash/function/curry'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
-const mapProps = (propsMapper, BaseComponent) => {
-  const MapProps = props => createElement(BaseComponent, propsMapper(props))
+const mapProps = (propsMapper, BaseComponent) =>
+  props => createElement(BaseComponent, propsMapper(props))
 
-  MapProps.displayName = wrapDisplayName(BaseComponent, 'mapProps')
-
-  return MapProps
-}
-
-export default curry(mapProps)
+export default createHelper(mapProps, 'mapProps')

--- a/src/packages/recompose/mapPropsOnChange.js
+++ b/src/packages/recompose/mapPropsOnChange.js
@@ -1,15 +1,13 @@
 import { Component } from 'react'
-import curry from 'lodash/function/curry'
-import wrapDisplayName from './wrapDisplayName'
-import shallowEqual from './shallowEqual'
 import pick from 'lodash/object/pick'
+import shallowEqual from './shallowEqual'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
 const mapPropsOnChange = (depdendentPropKeys, propsMapper, BaseComponent) => {
   const pickDependentProps = props => pick(props, depdendentPropKeys)
 
   return class extends Component {
-    static displayName = wrapDisplayName(BaseComponent, 'mapPropsOnChange')
     childProps = propsMapper(this.props)
 
     componentWillReceiveProps(nextProps) {
@@ -27,4 +25,4 @@ const mapPropsOnChange = (depdendentPropKeys, propsMapper, BaseComponent) => {
   }
 }
 
-export default curry(mapPropsOnChange)
+export default createHelper(mapPropsOnChange, 'mapPropsOnChange')

--- a/src/packages/recompose/onlyUpdateForKeys.js
+++ b/src/packages/recompose/onlyUpdateForKeys.js
@@ -1,11 +1,10 @@
 import pick from 'lodash/object/pick'
-import curry from 'lodash/function/curry'
 import shouldUpdate from './shouldUpdate'
 import shallowEqual from './shallowEqual'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 
-const onlyUpdateForKeys = (propKeys, BaseComponent) => {
-  const OnlyUpdateForKeys = shouldUpdate(
+const onlyUpdateForKeys = (propKeys, BaseComponent) =>
+  shouldUpdate(
     (props, nextProps) => !shallowEqual(
       pick(nextProps, propKeys),
       pick(props, propKeys)
@@ -13,12 +12,4 @@ const onlyUpdateForKeys = (propKeys, BaseComponent) => {
     BaseComponent
   )
 
-  OnlyUpdateForKeys.displayName = wrapDisplayName(
-    BaseComponent,
-    'onlyUpdateForKeys'
-  )
-
-  return OnlyUpdateForKeys
-}
-
-export default curry(onlyUpdateForKeys)
+export default createHelper(onlyUpdateForKeys, 'onlyUpdateForKeys')

--- a/src/packages/recompose/onlyUpdateForPropTypes.js
+++ b/src/packages/recompose/onlyUpdateForPropTypes.js
@@ -1,14 +1,14 @@
 import onlyUpdateForKeys from './onlyUpdateForKeys'
-import wrapDisplayName from './wrapDisplayName'
-import getDisplayName from './getDisplayName'
+import createHelper from './createHelper'
 
-const onlyUpdateForPropTypes = (BaseComponent) => {
+const onlyUpdateForPropTypes = BaseComponent => {
   const propTypes = BaseComponent.propTypes
 
   if (process.env.NODE_ENV !== 'production') {
+    const getDisplayName = require('./getDisplayName')
     if (!propTypes) {
       /* eslint-disable */
-      console.warn(
+      console.error(
         'A component without any `propTypes` was passed to ' +
         '`onlyUpdateForPropTypes()`. Check the implementation of the ' +
         `component with display name "${getDisplayName(BaseComponent)}".`
@@ -20,12 +20,7 @@ const onlyUpdateForPropTypes = (BaseComponent) => {
   const propKeys = Object.keys(propTypes || {})
   const OnlyUpdateForPropTypes = onlyUpdateForKeys(propKeys, BaseComponent)
 
-  OnlyUpdateForPropTypes.displayName = wrapDisplayName(
-    BaseComponent,
-    'onlyUpdateForPropTypes'
-  )
-
   return OnlyUpdateForPropTypes
 }
 
-export default onlyUpdateForPropTypes
+export default createHelper(onlyUpdateForPropTypes, 'onlyUpdateForPropTypes')

--- a/src/packages/recompose/pure.js
+++ b/src/packages/recompose/pure.js
@@ -1,15 +1,7 @@
 import shouldUpdate from './shouldUpdate'
 import shallowEqual from './shallowEqual'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 
-const pure = BaseComponent => {
-  const Pure = shouldUpdate(
-    (props, nextProps) => !shallowEqual(props, nextProps)
-  )(BaseComponent)
+const pure = shouldUpdate((props, nextProps) => !shallowEqual(props, nextProps))
 
-  Pure.displayName = wrapDisplayName(BaseComponent, 'pure')
-
-  return Pure
-}
-
-export default pure
+export default createHelper(pure, 'pure', 1)

--- a/src/packages/recompose/renameProp.js
+++ b/src/packages/recompose/renameProp.js
@@ -1,17 +1,11 @@
-import curry from 'lodash/function/curry'
 import omit from 'lodash/object/omit'
-import wrapDisplayName from './wrapDisplayName'
 import mapProps from './mapProps'
+import createHelper from './createHelper'
 
-const renameProp = (oldName, newName, BaseComponent) => {
-  const RenameProp = mapProps(props => ({
+const renameProp = (oldName, newName, BaseComponent) =>
+  mapProps(props => ({
     ...omit(props, oldName),
     [newName]: props[oldName]
   }), BaseComponent)
 
-  RenameProp.displayName = wrapDisplayName(BaseComponent, 'renameProp')
-
-  return RenameProp
-}
-
-export default curry(renameProp)
+export default createHelper(renameProp, 'renameProp')

--- a/src/packages/recompose/renameProps.js
+++ b/src/packages/recompose/renameProps.js
@@ -1,14 +1,13 @@
-import curry from 'lodash/function/curry'
 import omit from 'lodash/object/omit'
 import pick from 'lodash/object/pick'
 import mapKeys from 'lodash/object/mapKeys'
-import wrapDisplayName from './wrapDisplayName'
 import mapProps from './mapProps'
+import createHelper from './createHelper'
 
 const { keys } = Object
 
-const renameProps = (nameMap, BaseComponent) => {
-  const RenameProps = mapProps(props => ({
+const renameProps = (nameMap, BaseComponent) =>
+  mapProps(props => ({
     ...omit(props, keys(nameMap)),
     ...mapKeys(
       pick(props, keys(nameMap)),
@@ -16,9 +15,4 @@ const renameProps = (nameMap, BaseComponent) => {
     )
   }), BaseComponent)
 
-  RenameProps.displayName = wrapDisplayName(BaseComponent, 'renameProps')
-
-  return RenameProps
-}
-
-export default curry(renameProps)
+export default createHelper(renameProps, 'renameProps')

--- a/src/packages/recompose/renderComponent.js
+++ b/src/packages/recompose/renderComponent.js
@@ -1,5 +1,5 @@
-import curry from 'lodash/function/curry'
+import createHelper from 'lodash/function/curry'
 
-const renderComponent = curry((Component, _) => Component)
+const renderComponent = (Component, _) => Component
 
-export default renderComponent
+export default createHelper(renderComponent, 'renderComponent')

--- a/src/packages/recompose/renderNothing.js
+++ b/src/packages/recompose/renderNothing.js
@@ -1,7 +1,9 @@
+import createHelper from './createHelper'
+
 const renderNothing = _ => {
   const Nothing = () => null
   Nothing.displayName = 'Nothing'
   return Nothing
 }
 
-export default renderNothing
+export default createHelper(renderNothing, 'renderNothing', 1, false)

--- a/src/packages/recompose/setDisplayName.js
+++ b/src/packages/recompose/setDisplayName.js
@@ -1,5 +1,6 @@
 import setStatic from './setStatic'
+import createHelper from './createHelper'
 
-const setPropTypes = setStatic('displayName')
+const setDisplayName = setStatic('displayName')
 
-export default setPropTypes
+export default createHelper(setDisplayName, 'setDisplayName', 2, false)

--- a/src/packages/recompose/setPropTypes.js
+++ b/src/packages/recompose/setPropTypes.js
@@ -1,5 +1,6 @@
 import setStatic from './setStatic'
+import createHelper from './createHelper'
 
 const setPropTypes = setStatic('propTypes')
 
-export default setPropTypes
+export default createHelper(setPropTypes, 'setPropTypes', 2, false)

--- a/src/packages/recompose/setStatic.js
+++ b/src/packages/recompose/setStatic.js
@@ -1,8 +1,8 @@
-import curry from 'lodash/function/curry'
+import createHelper from './createHelper'
 
 const setStatic = (key, value, BaseComponent) => {
   BaseComponent[key] = value
   return BaseComponent
 }
 
-export default curry(setStatic)
+export default createHelper(setStatic, 'setStatic', 3, false)

--- a/src/packages/recompose/shouldUpdate.js
+++ b/src/packages/recompose/shouldUpdate.js
@@ -1,12 +1,9 @@
 import { Component } from 'react'
-import curry from 'lodash/function/curry'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
-const shouldUpdate = (test, BaseComponent) => (
+const shouldUpdate = (test, BaseComponent) =>
   class extends Component {
-    static displayName = wrapDisplayName(BaseComponent, 'shouldUpdate')
-
     shouldComponentUpdate(nextProps) {
       return test(this.props, nextProps)
     }
@@ -15,6 +12,5 @@ const shouldUpdate = (test, BaseComponent) => (
       return createElement(BaseComponent, this.props)
     }
   }
-)
 
-export default curry(shouldUpdate)
+export default createHelper(shouldUpdate, 'shouldUpdate')

--- a/src/packages/recompose/withContext.js
+++ b/src/packages/recompose/withContext.js
@@ -1,15 +1,13 @@
 import { Component } from 'react'
-import curry from 'lodash/function/curry'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
 const withContext = (
   childContextTypes,
   getChildContext,
   BaseComponent
-) => (
+) =>
   class extends Component {
-    static displayName = wrapDisplayName(BaseComponent, 'withContext')
     static childContextTypes = childContextTypes
     getChildContext = () => getChildContext(this.props)
 
@@ -17,6 +15,5 @@ const withContext = (
       return createElement(BaseComponent, this.props)
     }
   }
-)
 
-export default curry(withContext)
+export default createHelper(withContext, 'withContext')

--- a/src/packages/recompose/withProps.js
+++ b/src/packages/recompose/withProps.js
@@ -1,18 +1,12 @@
-import curry from 'lodash/function/curry'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
-const withProps = (props, BaseComponent) => {
-  const WithProps = ownerProps => (
+const withProps = (props, BaseComponent) =>
+  ownerProps => (
     createElement(BaseComponent, {
       ...ownerProps,
       ...props
     })
   )
 
-  WithProps.displayName = wrapDisplayName(BaseComponent, 'withProps')
-
-  return WithProps
-}
-
-export default curry(withProps)
+export default createHelper(withProps, 'withProps')

--- a/src/packages/recompose/withReducer.js
+++ b/src/packages/recompose/withReducer.js
@@ -1,7 +1,6 @@
 import { Component } from 'react'
-import curry from 'lodash/function/curry'
 import isFunction from 'lodash/lang/isFunction'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
 const withReducer = (
@@ -10,10 +9,8 @@ const withReducer = (
   reducer,
   initialState,
   BaseComponent
-) => (
+) =>
   class extends Component {
-    static displayName = wrapDisplayName(BaseComponent, 'withReducer')
-
     state = {
       stateValue: isFunction(initialState)
         ? initialState(this.props)
@@ -32,6 +29,5 @@ const withReducer = (
       })
     }
   }
-)
 
-export default curry(withReducer)
+export default createHelper(withReducer, 'withReducer')

--- a/src/packages/recompose/withState.js
+++ b/src/packages/recompose/withState.js
@@ -1,7 +1,6 @@
 import { Component } from 'react'
-import curry from 'lodash/function/curry'
 import isFunction from 'lodash/lang/isFunction'
-import wrapDisplayName from './wrapDisplayName'
+import createHelper from './createHelper'
 import createElement from './createElement'
 
 export const withState = (
@@ -9,9 +8,8 @@ export const withState = (
   stateUpdaterName,
   initialState,
   BaseComponent
-) => (
+) =>
   class extends Component {
-    static displayName = wrapDisplayName(BaseComponent, 'withState')
     state = {
       stateValue: isFunction(initialState)
         ? initialState(this.props)
@@ -32,6 +30,5 @@ export const withState = (
       })
     }
   }
-)
 
-export default curry(withState)
+export default createHelper(withState, 'withState')

--- a/src/packages/rx-recompose/observeProps.js
+++ b/src/packages/rx-recompose/observeProps.js
@@ -1,13 +1,10 @@
 import { Component } from 'react'
-import curry from 'lodash/function/curry'
 import createElement from 'recompose/createElement'
-import wrapDisplayName from 'recompose/wrapDisplayName'
+import createHelper from 'recompose/createHelper'
 import { Subject } from 'rx'
 
 const observeProps = (propsSequenceMapper, BaseComponent) => (
   class extends Component {
-    static displayName = wrapDisplayName(BaseComponent, 'observeProps')
-
     state = {}
 
     // Subject that receives props from owner
@@ -53,4 +50,4 @@ const observeProps = (propsSequenceMapper, BaseComponent) => (
   }
 )
 
-export default curry(observeProps)
+export default createHelper(observeProps, 'observeProps')


### PR DESCRIPTION
Adds a new module `createHelper()`. In production, it is an alias for `lodash.curry()`. In development, it is a custom curry function that adds special flags to partially applied higher-order component helpers. The `compose()` module has been updated to use these flags to detect if a helper has been applied with insufficient arguments.

`createHelper()` also takes over the responsibility of wrapping a BaseComponent's display name. Likewise, this only happens in development.