### PR TITLE
Allow mapPropsStream to return an object of streams

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,7 +38,6 @@ module.exports = function(config) {
       dir: 'coverage',
       reporters: [
         { type: 'lcov', subdir: '.' },
-        { type: 'text', subdir: '.' },
         { type: 'html', subdir: '.' }
       ]
     },
@@ -51,7 +50,8 @@ module.exports = function(config) {
           exclude: [
             /__tests__/,
             /node_modules/,
-            path.resolve(__dirname, './src/packages/recompose-relay/data')
+            path.resolve(__dirname, './src/packages/recompose-relay/data'),
+            path.resolve(__dirname, './src/karma.conf.js')
           ],
           loader: 'isparta'
         }, {

--- a/src/packages/rx-recompose/README.md
+++ b/src/packages/rx-recompose/README.md
@@ -50,7 +50,7 @@ const mapPropsStream2 = () => ({
 })
 ```
 
-The second form is often more convenient, but note that it is also more limiting: you must explicitly declare every prop that is passed to the base component. There's no way to pass through arbitrary props from the owner. For full control over the stream of props, use the first form.
+The second form is often more convenient because it avoids the need for `Observable.combineLatest()`, but note that it is also more limiting: you must explicitly declare every prop that is passed to the base component. There's no way to pass through arbitrary props from the owner. For full control over the stream of props, use the first form.
 
 ### `createEventHandler()`
 

--- a/src/packages/rx-recompose/README.md
+++ b/src/packages/rx-recompose/README.md
@@ -40,9 +40,9 @@ Maps an observable stream of owner props to a stream of child props, or to an ob
 In the second form, an object of streams is turned into an stream of objects. The result is then combined with the stream of owner props. To illustrate, the following two `mapPropsStream()` functions are equivalent:
 
 ```js
-const mapPropsStream1 = $ownerProps =>
+const mapPropsStream1 = ownerProps$ =>
   Observable.combineLatest(
-    $ownerProps, Observable.just({ a, b, c }),
+    ownerProps$, Observable.just({ a, b, c }),
     (ownerProps, { a, b, c }) => ({
       ...ownerProps,
       a,

--- a/src/packages/rx-recompose/README.md
+++ b/src/packages/rx-recompose/README.md
@@ -9,19 +9,6 @@ rx-recompose
 npm install --save rx-recompose
 ```
 
-## API
-
-### `observeProps()`
-
-```js
-observeProps(
-  mapPropsStream: (props$: Observable) => Observable,
-  BaseComponent: ReactElementType
-): ReactElementType
-```
-
-Maps an observable stream of owner props to a stream of child props.
-
 It turns out that much of the React Component API can be expressed in terms of observables:
 
 - Instead of `setState()`, combine multiple streams together.
@@ -35,7 +22,43 @@ Other benefits include:
 - Sideways data loading is trivial – just combine the props stream with an external stream.
 - Access to the full ecosystem of RxJS libraries.
 
-(Examples to come.)
+Examples to come.
+
+## API
+
+### `observeProps()`
+
+```js
+observeProps(
+  mapPropsStream: (props$: Observable) => Observable | { [propKey: string]: Observable },
+  BaseComponent: ReactElementType
+): ReactElementType
+```
+
+Maps an observable stream of owner props to a stream of child props, or to an object of observables.
+
+In the second form, an object of streams is turned into an stream of objects. The result is then combined with the stream of owner props. To illustrate, the following two `mapPropsStream()` functions are equivalent:
+
+```js
+const mapPropsStream1 = $ownerProps =>
+  Observable.combineLatest(
+    $ownerProps, Observable.just({ a, b, c }),
+    (ownerProps, { a, b, c }) => ({
+      ...ownerProps,
+      a,
+      b,
+      c
+    })
+  )
+// Same as
+const mapPropsStream2 = () => ({
+  a: Observable.just(a),
+  b: Observable.just(b),
+  c: Observable.just(c)
+})
+```
+
+The second form is often more convenient, but note that it is also more limiting: there's no to filter out unwanted owner props, since the props returned by the mapping function are always merged with the owner props. Relatedly, a prop received from the owner will always result in a new render. For full control over the stream of props, use the first form.
 
 ### `createEventHandler()`
 

--- a/src/packages/rx-recompose/README.md
+++ b/src/packages/rx-recompose/README.md
@@ -37,19 +37,11 @@ observeProps(
 
 Maps an observable stream of owner props to a stream of child props, or to an object of observables.
 
-In the second form, an object of streams is turned into an stream of objects. The result is then combined with the stream of owner props. To illustrate, the following two `mapPropsStream()` functions are equivalent:
+In the second form, an object of streams is turned into an stream of objects. To illustrate, the following two `mapPropsStream()` functions are equivalent:
 
 ```js
-const mapPropsStream1 = ownerProps$ =>
-  Observable.combineLatest(
-    ownerProps$, Observable.just({ a, b, c }),
-    (ownerProps, { a, b, c }) => ({
-      ...ownerProps,
-      a,
-      b,
-      c
-    })
-  )
+const mapPropsStream1 = () => Observable.just({ a, b, c }),
+
 // Same as
 const mapPropsStream2 = () => ({
   a: Observable.just(a),
@@ -58,7 +50,7 @@ const mapPropsStream2 = () => ({
 })
 ```
 
-The second form is often more convenient, but note that it is also more limiting: there's no to filter out unwanted owner props, since the props returned by the mapping function are always merged with the owner props. Relatedly, a prop received from the owner will always result in a new render. For full control over the stream of props, use the first form.
+The second form is often more convenient, but note that it is also more limiting: you must explicitly declare every prop that is passed to the base component. There's no way to pass through arbitrary props from the owner. For full control over the stream of props, use the first form.
 
 ### `createEventHandler()`
 

--- a/src/packages/rx-recompose/__tests__/observeProps-test.js
+++ b/src/packages/rx-recompose/__tests__/observeProps-test.js
@@ -14,7 +14,7 @@ import {
   createRenderer
 } from 'react-addons-test-utils'
 
-const createSmartButton = BaseComponent =>
+const createSmartButton1 = BaseComponent =>
   observeProps(props$ => {
     const increment$ = createEventHandler()
     const count$ = increment$
@@ -43,53 +43,63 @@ const createSmartButton2 = BaseComponent =>
 
 const Button = toClass(props => <button {...props} />)
 
-function testSmartButton(element) {
-  const tree = renderIntoDocument(element)
-  const button = findRenderedComponentWithType(tree, Button)
-  const buttonNode = findRenderedDOMComponentWithTag(tree, 'button')
-
-  Simulate.click(buttonNode)
-  Simulate.click(buttonNode)
-  Simulate.click(buttonNode)
-
-  expect(button.props.count).to.equal(3)
-  expect(button.props.pass).to.equal('through')
-}
-
-describe('observeProps()', () => {
+describe.only('observeProps()', () => {
   it('maps a stream of owner props to a stream of child props', () => {
-    const SmartButton = createSmartButton(props => <Button {...props} />)
+    const SmartButton = createSmartButton1(props => <Button {...props} />)
     expect(SmartButton.displayName).to.equal('observeProps(Component)')
-    testSmartButton(<SmartButton pass="through" />)
+
+    const tree = renderIntoDocument(<SmartButton pass="through" />)
+    const button = findRenderedComponentWithType(tree, Button)
+    const buttonNode = findRenderedDOMComponentWithTag(tree, 'button')
+
+    Simulate.click(buttonNode)
+    Simulate.click(buttonNode)
+    Simulate.click(buttonNode)
+
+    expect(button.props.count).to.equal(3)
+    expect(button.props.pass).to.equal('through')
   })
 
   it('maps a stream of owner props to an object of child prop streams', () => {
     const SmartButton = createSmartButton2(props => <Button {...props} />)
     expect(SmartButton.displayName).to.equal('observeProps(Component)')
-    testSmartButton(<SmartButton pass="through" />)
+
+    const tree = renderIntoDocument(<SmartButton pass="through" />)
+    const button = findRenderedComponentWithType(tree, Button)
+    const buttonNode = findRenderedDOMComponentWithTag(tree, 'button')
+
+    Simulate.click(buttonNode)
+    Simulate.click(buttonNode)
+    Simulate.click(buttonNode)
+
+    expect(button.props.count).to.equal(3)
+    expect(button.props.pass).to.be.undefined
   })
 
   it('works on initial render', () => {
-    const SmartButton = createSmartButton(props => <Button {...props} />)
+    const SmartButton1 = createSmartButton1(props => <Button {...props} />)
     const SmartButton2 = createSmartButton2(props => <Button {...props} />)
 
     // Test using shallow renderer, which only renders once
-    const renderer = createRenderer()
+    const renderer1 = createRenderer()
 
-    renderer.render(<SmartButton pass="through" />)
-    const button1 = renderer.getRenderOutput()
+    renderer1.render(<SmartButton1 pass="through" />)
+    const button1 = renderer1.getRenderOutput()
     expect(button1.props.pass).to.equal('through')
     expect(button1.props.count).to.equal(0)
 
-    renderer.render(<SmartButton2 pass="through" />)
-    const button2 = renderer.getRenderOutput()
-    expect(button2.props.pass).to.equal('through')
+
+    const renderer2 = createRenderer()
+
+    renderer2.render(<SmartButton2 pass="through" />)
+    const button2 = renderer2.getRenderOutput()
+    expect(button2.props.pass).to.be.undefined
     expect(button2.props.count).to.equal(0)
   })
 
   it('receives prop updates', () => {
     const spy = createSpy()
-    const SmartButton = createSmartButton(spy('div'))
+    const SmartButton = createSmartButton1(spy('div'))
 
     const Container = withState('label', 'updateLabel', 'Count', SmartButton)
 


### PR DESCRIPTION
Updates the type signature of the `mapPropsStream` of `observeProps`:

```js
observeProps(
  mapPropsStream: (props$: Observable) => Observable | { [propKey: string]: Observable },
  BaseComponent: ReactElementType
): ReactElementType
```

In the new second form, an object of streams is turned into an stream of objects. To illustrate, the following two `mapPropsStream()` functions are equivalent:

```js
const mapPropsStream1 = () => Observable.just({ a, b, c }),

// Same as
const mapPropsStream2 = () => ({
  a: Observable.just(a),
  b: Observable.just(b),
  c: Observable.just(c)
})
```

The second form is often more convenient because it avoids the need for `Observable.combineLatest`, but note that it is also more limiting: you must explicitly declare every prop that is passed to the base component. There's no way to pass through arbitrary props from the owner. For full control over the stream of props, use the first form.
