### PR TITLE
Suppress React's warning when setState() is called after unmount

### DIFF
--- a/src/packages/recompose/__tests__/withState-test.js
+++ b/src/packages/recompose/__tests__/withState-test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { expect } from 'chai'
 import omit from 'lodash/object/omit'
+import pick from 'lodash/object/pick'
 import { withState, compose } from 'recompose'
 import createSpy from 'recompose/createSpy'
 
@@ -12,6 +13,18 @@ describe('withState()', () => {
     withState('counter', 'updateCounter', 0),
     spy
   )('div')
+
+  const savedConsoleError = console.error // eslint-disable-line
+
+  beforeEach(() => {
+    console.error = (message) => {  // eslint-disable-line
+      throw new Error(message)
+    }
+  })
+
+  afterEach(() => {
+    console.error = savedConsoleError  // eslint-disable-line
+  })
 
   it('adds a stateful value and a function for updating it', () => {
     expect(Counter.displayName).to.equal(
@@ -73,4 +86,34 @@ describe('withState()', () => {
     expect(spy2.getProps().counter).to.equal(3)
   })
 
+  it('does not call setState after component unmount', () => {
+
+    const spy4 = createSpy()
+    const Counter4 = compose(
+      withState('counter', 'updateCounter', 0),
+      spy4
+    )('div')
+
+    const unmounterSpy = createSpy()
+    const Unmounter = compose(
+      withState('isMounted', 'setIsMounted', true),
+      unmounterSpy
+    )((props) => props.isMounted ? <Counter4/> : <div/>)
+
+    renderIntoDocument(<Unmounter />)
+
+    spy4.getProps().updateCounter(100)
+    expect(pick(spy4.getProps(), 'counter')).to.eql({
+      counter: 100,
+    })
+
+    const props = spy4.getProps()
+
+    unmounterSpy.getProps().setIsMounted(false)
+    expect(pick(unmounterSpy.getProps(), 'isMounted')).to.eql({
+      isMounted: false,
+    })
+
+    props.updateCounter(200)
+  })
 })

--- a/src/packages/recompose/withState.js
+++ b/src/packages/recompose/withState.js
@@ -16,11 +16,18 @@ export const withState = (
         : initialState
     }
 
+    hasUnmounted = false
+
     updateStateValue = (updateFn, callback) => (
-      this.setState(({ stateValue }) => ({
-        stateValue: isFunction(updateFn) ? updateFn(stateValue) : updateFn
-      }), callback)
+      !this.hasUnmounted &&
+        this.setState(({ stateValue }) => ({
+          stateValue: isFunction(updateFn) ? updateFn(stateValue) : updateFn
+        }), callback)
     )
+
+    componentWillUnmount() {
+      this.hasUnmounted = true
+    }
 
     render() {
       return createElement(BaseComponent, {


### PR DESCRIPTION
There are a lot of situation we call setState inside some asynchronous methods like promises, callbacks, in direct window events processing.

And component can be unmounted before asynchronous method has completed.

And calling withState method after component has unmounted causes error message in console like 
```
Error: Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the withState(spy(div)) component
```

I've added a test which emulates such behaviour, and fails on any console.error message.

This lines in test looks like a dirty hack, but I don't know a better solution
```javascript
  beforeEach(() => {
    console.error = (message) => {
      throw new Error(message)
    }
  })

  afterEach(() => {
    console.error = savedConsoleError
  })
```