### PR TITLE
Fix mapPropsOnChange

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -35,12 +35,12 @@ const omitProps = (keys, BaseComponent) => mapProps(omit(keys), BaseComponent);
 ```js
 mapPropsOnChange(
   depdendentPropKeys: Array<string>,
-  propsMapper: (ownerProps: Object) => Object,
+  propsMapper: (dependentProps: Object) => Object,
   BaseComponent: ReactElementType
 ): ReactElementType
 ```
 
-Same as `mapProps()`, but child props are only re-computed when one of the props specified by `dependentPropKeys` has been updated. This helps ensure that computationally intense `propsMapper` functions are only executed when necessary.
+Similar to as `mapProps()`, but child props are only re-computed when one of the props specified by `dependentPropKeys` has changed. This helps ensure that computationally intense `propsMapper` functions are only executed when necessary.
 
 ### `withProps()`
 

--- a/src/packages/recompose/mapPropsOnChange.js
+++ b/src/packages/recompose/mapPropsOnChange.js
@@ -1,5 +1,6 @@
 import { Component } from 'react'
 import pick from 'lodash/object/pick'
+import omit from 'lodash/object/omit'
 import shallowEqual from './shallowEqual'
 import createHelper from './createHelper'
 import createElement from './createElement'
@@ -8,19 +9,22 @@ const mapPropsOnChange = (depdendentPropKeys, propsMapper, BaseComponent) => {
   const pickDependentProps = props => pick(props, depdendentPropKeys)
 
   return class extends Component {
-    childProps = propsMapper(this.props)
+    computedProps = propsMapper(this.props)
 
     componentWillReceiveProps(nextProps) {
       if (!shallowEqual(
         pickDependentProps(this.props),
         pickDependentProps(nextProps)
       )) {
-        this.childProps = propsMapper(nextProps)
+        this.computedProps = propsMapper(nextProps)
       }
     }
 
     render() {
-      return createElement(BaseComponent, this.childProps)
+      return createElement(BaseComponent, {
+        ...this.computedProps,
+        ...omit(this.props, depdendentPropKeys)
+      })
     }
   }
 }


### PR DESCRIPTION
Change mapPropsOnChange so that propsMapper only receives the dependent props. Resulting object is combined with non-dependent props.

Closes #60