### PR TITLE
Fix typo in withReducer example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const counterReducer = (count, action) => {
 }
 
 const Counter = withReducer(
-  'count', 'dispatch', counterReducer, 0,
+  'counter', 'dispatch', counterReducer, 0,
   ({ counter, dispatch }) => (
     <div>
       Count: {counter}


### PR DESCRIPTION
Hi,

Just a small typo fix in README regarding the use of withReducer.