### PR TITLE
Improve rx-recompose example

### DIFF
--- a/src/packages/rx-recompose/README.md
+++ b/src/packages/rx-recompose/README.md
@@ -76,7 +76,8 @@ const Counter = observeProps(
     return {
       increment: Observable.just(increment$),
       decrement: Observable.just(decrement$),
-      count
+      count: Observable.just(count$),
+      style: props$.pluck('style'),
     }
   },
   ({ count, decrement, increment, ...props }) => (


### PR DESCRIPTION
I was playing with rx-recompose and got stuck when trying example. First, there was an error. Second, Counter was ignoring external props like `<Counter style={{color: 'red'}}/>`.

So, I had to patch it to:

- fix `ReferenceError: count is not defined`
- make mapPropsStream of example to actually pass props through

I'm just learning both Rx and recompose. Is my example correct? If not, I may re-submit PR tomorrow.

P.S.: Good job with rx-recompose :+1: 

UPDATED: do not merge yet, it's wrong :confused: 