### PR TITLE
Fix variable name error

### DIFF
--- a/src/packages/rx-recompose/README.md
+++ b/src/packages/rx-recompose/README.md
@@ -76,7 +76,7 @@ const Counter = observeProps(
     return {
       increment: Observable.just(increment$),
       decrement: Observable.just(decrement$),
-      count
+      count: count$
     }
   },
   ({ count, decrement, increment, ...props }) => (


### PR DESCRIPTION
```javascript
return {
      increment: Observable.just(increment$),
      decrement: Observable.just(decrement$),
      count: count$
}
```
instead of 
```javascript
return {
      increment: Observable.just(increment$),
      decrement: Observable.just(decrement$),
      count
}
```
in rx-recompose Readme demo.