### PR TITLE
Allow `withState` to be required by ES5 code

### DIFF
--- a/src/packages/recompose/withState.js
+++ b/src/packages/recompose/withState.js
@@ -3,7 +3,7 @@ import isFunction from 'lodash/lang/isFunction'
 import createHelper from './createHelper'
 import createElement from './createElement'
 
-export const withState = (
+const withState = (
   stateName,
   stateUpdaterName,
   initialState,


### PR DESCRIPTION
Most functions in recompose can be required from ES5 code:

```js
const compose = require('recompose/compose')
```

But not `withState`.

```js
const withState = require('recompose/withState')
```

```js
withState('a', 'b', 0) // ERROR: withState is not a function
```

This is because `withState.js` exports more than one thing.