### PR TITLE
lifecycle: Allow `null` in place of `() => {}`

### DIFF
--- a/src/packages/recompose/lifecycle.js
+++ b/src/packages/recompose/lifecycle.js
@@ -6,11 +6,15 @@ const lifecycle = (setup, teardown, BaseComponent) => (
   class Lifecycle extends React.Component {
     constructor(props, context) {
       super(props, context)
-      setup(this)
+      if (setup) {
+        setup(this)
+      }
     }
 
     componentWillUnmount() {
-      teardown(this)
+      if (teardown) {
+        teardown(this)
+      }
     }
 
     render() {


### PR DESCRIPTION
Some of our engineers passed `null` to `lifecycle()` instead of a no-op function `() => { }` or `_.noop`. This caused a run-time error in our staging environment.

This PR makes it allow falsy value to be a synonym for no-op. An alternative solution is to validate the arguments and throw immediately, so that these errors could be caught early.