### PR TITLE
Update lodash to v4

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -24,7 +24,7 @@ mapProps(
 
 Accepts a function that maps owner props to a new collection of props that are passed to the base component.
 
-`mapProps()` pairs well with functional utility libraries like [lodash-fp](https://github.com/lodash/lodash-fp). For example, Recompose does not come with a `omitProps()` function, but you can build one easily using lodash-fp's `omit()`:
+`mapProps()` pairs well with functional utility libraries like [lodash/fp](https://github.com/lodash/lodash/tree/npm/fp). For example, Recompose does not come with a `omitProps()` function, but you can build one easily using lodash-fp's `omit()`:
 
 ```js
 const omitProps = (keys, BaseComponent) => mapProps(omit(keys), BaseComponent);

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "karma-sinon": "^1.0.4",
     "karma-sourcemap-loader": "^0.3.5",
     "karma-webpack": "^1.7.0",
-    "lodash": "^3.10.1",
+    "lodash": "^4.0.0",
     "mocha": "^2.3.3",
     "phantomjs": "^1.9.18",
     "pretty-bytes": "^2.0.1",

--- a/src/packages/recompose-relay/package.json
+++ b/src/packages/recompose-relay/package.json
@@ -15,7 +15,7 @@
     "composition"
   ],
   "dependencies": {
-    "lodash": "^3.0.0"
+    "lodash": "^4.0.0"
   },
   "peerDependencies": {
     "recompose": "^0.9.1",

--- a/src/packages/recompose/__tests__/branch-test.js
+++ b/src/packages/recompose/__tests__/branch-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { expect } from 'chai'
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import { branch, compose, withState, withProps } from 'recompose'
 import createSpy from 'recompose/createSpy'
 

--- a/src/packages/recompose/__tests__/compose-test.js
+++ b/src/packages/recompose/__tests__/compose-test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { expect } from 'chai'
 import { compose, mapProps, setDisplayName } from 'recompose'
-import identity from 'lodash/utility/identity'
+import identity from 'lodash/identity'
 
 describe('compose()', () => {
   const BaseComponent = setDisplayName('BaseComponent', () => <div />)

--- a/src/packages/recompose/__tests__/createHelper-test.js
+++ b/src/packages/recompose/__tests__/createHelper-test.js
@@ -27,6 +27,7 @@ describe('createHelper()', () => {
     testEqualOutput(helper => helper()(a, b, c))
     testEqualOutput(helper => helper(null)(b, c))
     testEqualOutput(helper => helper(undefined)(b, c))
+    testEqualOutput(helper => helper(b, undefined, c))
   })
 
   it('properly sets display name', () => {

--- a/src/packages/recompose/__tests__/createHelper-test.js
+++ b/src/packages/recompose/__tests__/createHelper-test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import createHelper from '../createHelper'
-import lodashCurry from 'lodash/function/curry'
+import lodashCurry from 'lodash/curry'
 
 describe('createHelper()', () => {
   const func = (a, b, c) => ({ a, b, c })

--- a/src/packages/recompose/__tests__/createSpy-test.js
+++ b/src/packages/recompose/__tests__/createSpy-test.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react'
 import { expect } from 'chai'
 import { compose, withState, branch } from 'recompose'
 import createSpy from 'recompose/createSpy'
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import { NullComponent } from './utils'
 
 import { renderIntoDocument } from 'react-addons-test-utils'

--- a/src/packages/recompose/__tests__/doOnReceiveProps-test.js
+++ b/src/packages/recompose/__tests__/doOnReceiveProps-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { expect } from 'chai'
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import { doOnReceiveProps, compose, withState, mapProps } from 'recompose'
 import createSpy from 'recompose/createSpy'
 import { renderIntoDocument } from 'react-addons-test-utils'

--- a/src/packages/recompose/__tests__/lifecycle-test.js
+++ b/src/packages/recompose/__tests__/lifecycle-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { expect } from 'chai'
-import identity from 'lodash/utility/identity'
+import identity from 'lodash/identity'
 import { lifecycle, compose, withState, branch } from 'recompose'
 import createSpy from 'recompose/createSpy'
 

--- a/src/packages/recompose/__tests__/mapProps-test.js
+++ b/src/packages/recompose/__tests__/mapProps-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { expect } from 'chai'
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import { mapProps, withState, compose } from 'recompose'
 import createSpy from 'recompose/createSpy'
 

--- a/src/packages/recompose/__tests__/mapPropsOnChange-test.js
+++ b/src/packages/recompose/__tests__/mapPropsOnChange-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { expect } from 'chai'
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import { mapPropsOnChange, withState, flattenProp, compose } from 'recompose'
 import createSpy from 'recompose/createSpy'
 

--- a/src/packages/recompose/__tests__/onlyUpdateForKeys-test.js
+++ b/src/packages/recompose/__tests__/onlyUpdateForKeys-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { expect } from 'chai'
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import { onlyUpdateForKeys, compose, withState } from 'recompose'
 import createSpy from 'recompose/createSpy'
 

--- a/src/packages/recompose/__tests__/onlyUpdateForPropTypes-test.js
+++ b/src/packages/recompose/__tests__/onlyUpdateForPropTypes-test.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react'
 import { expect } from 'chai'
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 
 import {
   onlyUpdateForPropTypes,

--- a/src/packages/recompose/__tests__/pure-test.js
+++ b/src/packages/recompose/__tests__/pure-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { expect } from 'chai'
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import { pure, compose, withState } from 'recompose'
 import createSpy from 'recompose/createSpy'
 

--- a/src/packages/recompose/__tests__/shouldUpdate-test.js
+++ b/src/packages/recompose/__tests__/shouldUpdate-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { expect } from 'chai'
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import { shouldUpdate, compose, withState } from 'recompose'
 import createSpy from 'recompose/createSpy'
 

--- a/src/packages/recompose/__tests__/withReducer-test.js
+++ b/src/packages/recompose/__tests__/withReducer-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { expect } from 'chai'
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import { withReducer, compose, flattenProp } from 'recompose'
 import createSpy from 'recompose/createSpy'
 

--- a/src/packages/recompose/__tests__/withState-test.js
+++ b/src/packages/recompose/__tests__/withState-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { expect } from 'chai'
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import { withState, compose } from 'recompose'
 import createSpy from 'recompose/createSpy'
 

--- a/src/packages/recompose/componentFromProp.js
+++ b/src/packages/recompose/componentFromProp.js
@@ -1,4 +1,4 @@
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import createHelper from './createHelper'
 import createElement from './createElement'
 

--- a/src/packages/recompose/compose.js
+++ b/src/packages/recompose/compose.js
@@ -1,7 +1,7 @@
-import lodashCompose from 'lodash/function/compose'
+import flowRight from 'lodash/flowRight'
 
-// In production, use lodash's compose
-let compose = lodashCompose
+// In production, use lodash's flowRight
+let compose = flowRight
 
 // In development, print warnings when composing higher-order component helpers
 // that have been applied with too few parameters

--- a/src/packages/recompose/compose.js
+++ b/src/packages/recompose/compose.js
@@ -42,11 +42,11 @@ if (process.env.NODE_ENV !== 'production') {
           )
         })
 
-        return lodashCompose(...funcs)(BaseComponent)
+        return flowRight(...funcs)(BaseComponent)
       }
     }
 
-    return lodashCompose(...funcs)
+    return flowRight(...funcs)
   }
 }
 

--- a/src/packages/recompose/createHelper.js
+++ b/src/packages/recompose/createHelper.js
@@ -9,7 +9,8 @@ const createHelper = (func, helperName, _helperLength, setDisplayName = true) =>
     // to the base commponent.
     const wrapDisplayName = require('./wrapDisplayName')
     const apply = (previousArgs, nextArgs) => {
-      const args = previousArgs.concat(nextArgs)
+      const filteredArgs = nextArgs.filter(ident => ident !== undefined)
+      const args = previousArgs.concat(filteredArgs)
       const argsLength = args.length
 
       if (argsLength < helperLength) {

--- a/src/packages/recompose/createHelper.js
+++ b/src/packages/recompose/createHelper.js
@@ -1,4 +1,4 @@
-import curry from 'lodash/function/curry'
+import curry from 'lodash/curry'
 
 const createHelper = (func, helperName, _helperLength, setDisplayName = true) => {
   const helperLength = _helperLength || func.length

--- a/src/packages/recompose/flattenProp.js
+++ b/src/packages/recompose/flattenProp.js
@@ -1,4 +1,4 @@
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import createHelper from './createHelper'
 import createElement from './createElement'
 

--- a/src/packages/recompose/mapPropsOnChange.js
+++ b/src/packages/recompose/mapPropsOnChange.js
@@ -1,6 +1,6 @@
 import { Component } from 'react'
-import pick from 'lodash/object/pick'
-import omit from 'lodash/object/omit'
+import pick from 'lodash/pick'
+import omit from 'lodash/omit'
 import shallowEqual from './shallowEqual'
 import createHelper from './createHelper'
 import createElement from './createElement'

--- a/src/packages/recompose/onlyUpdateForKeys.js
+++ b/src/packages/recompose/onlyUpdateForKeys.js
@@ -1,4 +1,4 @@
-import pick from 'lodash/object/pick'
+import pick from 'lodash/pick'
 import shouldUpdate from './shouldUpdate'
 import shallowEqual from './shallowEqual'
 import createHelper from './createHelper'

--- a/src/packages/recompose/package.json
+++ b/src/packages/recompose/package.json
@@ -10,8 +10,8 @@
     "composition"
   ],
   "dependencies": {
-    "lodash": "^3.0.0",
-    "hoist-non-react-statics": "^1.0.0"
+    "hoist-non-react-statics": "^1.0.0",
+    "lodash": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^0.14.0"

--- a/src/packages/recompose/renameProp.js
+++ b/src/packages/recompose/renameProp.js
@@ -1,4 +1,4 @@
-import omit from 'lodash/object/omit'
+import omit from 'lodash/omit'
 import mapProps from './mapProps'
 import createHelper from './createHelper'
 

--- a/src/packages/recompose/renameProps.js
+++ b/src/packages/recompose/renameProps.js
@@ -1,6 +1,6 @@
-import omit from 'lodash/object/omit'
-import pick from 'lodash/object/pick'
-import mapKeys from 'lodash/object/mapKeys'
+import omit from 'lodash/omit'
+import pick from 'lodash/pick'
+import mapKeys from 'lodash/mapKeys'
 import mapProps from './mapProps'
 import createHelper from './createHelper'
 

--- a/src/packages/recompose/withProps.js
+++ b/src/packages/recompose/withProps.js
@@ -1,4 +1,4 @@
-import isFunction from 'lodash/lang/isFunction'
+import isFunction from 'lodash/isFunction'
 import createHelper from './createHelper'
 import createElement from './createElement'
 

--- a/src/packages/recompose/withReducer.js
+++ b/src/packages/recompose/withReducer.js
@@ -1,5 +1,5 @@
 import { Component } from 'react'
-import isFunction from 'lodash/lang/isFunction'
+import isFunction from 'lodash/isFunction'
 import createHelper from './createHelper'
 import createElement from './createElement'
 

--- a/src/packages/recompose/withState.js
+++ b/src/packages/recompose/withState.js
@@ -1,5 +1,5 @@
 import { Component } from 'react'
-import isFunction from 'lodash/lang/isFunction'
+import isFunction from 'lodash/isFunction'
 import createHelper from './createHelper'
 import createElement from './createElement'
 

--- a/src/packages/rx-recompose/__tests__/observeProps-test.js
+++ b/src/packages/rx-recompose/__tests__/observeProps-test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import React from 'react'
 import { Observable } from 'rx'
 import { toClass, withState, compose, branch } from 'recompose'
-import identity from 'lodash/utility/identity'
+import identity from 'lodash/identity'
 import createSpy from 'recompose/createSpy'
 import { observeProps, createEventHandler } from 'rx-recompose'
 

--- a/src/packages/rx-recompose/observeProps.js
+++ b/src/packages/rx-recompose/observeProps.js
@@ -1,6 +1,6 @@
 import { Component } from 'react'
 import { Observable, Subject } from 'rx'
-import isPlainObject from 'lodash/lang/isPlainObject'
+import isPlainObject from 'lodash/isPlainObject'
 import createElement from 'recompose/createElement'
 import createHelper from 'recompose/createHelper'
 

--- a/src/packages/rx-recompose/package.json
+++ b/src/packages/rx-recompose/package.json
@@ -15,7 +15,7 @@
     "composition"
   ],
   "dependencies": {
-    "lodash": "^3.0.0"
+    "lodash": "^4.0.0"
   },
   "peerDependencies": {
     "recompose": "^0.9.1",


### PR DESCRIPTION
This PR simply updates the "lodash" dependency to v4 and fixes any references to old module locations or deprecated functions.