### PR TITLE
Bump lodash and revert to correct curry behavior

### DIFF
--- a/src/packages/recompose/createHelper.js
+++ b/src/packages/recompose/createHelper.js
@@ -9,10 +9,7 @@ const createHelper = (func, helperName, _helperLength, setDisplayName = true) =>
     // to the base commponent.
     const wrapDisplayName = require('./wrapDisplayName')
     const apply = (previousArgs, nextArgs) => {
-      const filteredArgs = nextArgs.filter(
-        ident => typeof ident !== 'undefined'
-      )
-      const args = previousArgs.concat(filteredArgs)
+      const args = previousArgs.concat(nextArgs)
       const argsLength = args.length
 
       if (argsLength < helperLength) {

--- a/src/packages/recompose/package.json
+++ b/src/packages/recompose/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "hoist-non-react-statics": "^1.0.0",
-    "lodash": "^4.0.0"
+    "lodash": "^4.3.0"
   },
   "peerDependencies": {
     "react": "^0.14.0"


### PR DESCRIPTION
Re https://github.com/acdlite/recompose/pull/92#issuecomment-181163598:

Lodash 4.3.0 fixes the incorrect curry behavior. This bumps Lodash and reverts 07c1564.

I know that @acdlite proposed [not using Lodash's curry at all](https://github.com/acdlite/recompose/pull/92#issuecomment-181189168), but here's a simpler change in the meantime.