### PR TITLE
Make createEventHandler accept an optional function for cancelling events

### DIFF
--- a/src/packages/rx-recompose/README.md
+++ b/src/packages/rx-recompose/README.md
@@ -55,7 +55,9 @@ The second form is often more convenient because it avoids the need for `Observa
 ### `createEventHandler()`
 
 ```js
-createEventHandler(): Function & Subject
+createEventHandler(
+  callback: ?(value: any) => any
+): Function & Subject
 ```
 
 Creates a Subject that is also a function. When called, the subject emits a new value. This type of function is ideal for passing event handlers from `observeProps()`:
@@ -87,4 +89,15 @@ const Counter = observeProps(
     </div>
   )
 )
+```
+
+Allows one optional function argument, that will be called every time the eventHandler is called,
+with the same argument, and will yield the return value of that same callback. This way, you can
+totally cancel a form submission using the eventHandler:
+
+```
+const onSubmit = createEventHandler(e => {
+  e.preventDefault()
+  return false
+})
 ```

--- a/src/packages/rx-recompose/__tests__/createEventHandler-test.js
+++ b/src/packages/rx-recompose/__tests__/createEventHandler-test.js
@@ -14,4 +14,23 @@ describe('createEventHandler()', () => {
     subscription.dispose()
     expect(result).to.eql([1, 2, 3])
   })
+
+  it('calls the function passed in and returns its return value', () => {
+    const result = []
+    const eventHandler = createEventHandler(e => {
+      e.preventDefault()
+      return false
+    })
+    const subscription = eventHandler.subscribe(v => result.push(v))
+    let preventDefaultCalled = false
+    const event = {
+      preventDefault: () => {
+        preventDefaultCalled = true
+      }
+    }
+    expect(eventHandler(event)).to.eql(false)
+    expect(preventDefaultCalled).to.eql(true)
+    subscription.dispose()
+    expect(result).to.eql([event])
+  })
 })

--- a/src/packages/rx-recompose/createEventHandler.js
+++ b/src/packages/rx-recompose/createEventHandler.js
@@ -2,9 +2,12 @@ import { Subject } from 'rx'
 
 // Idea and implementation borrowed from
 // https://github.com/fdecampredon/rx-react
-const createEventHandler = () => {
+const createEventHandler = (fn) => {
   function subject(value) {
     subject.onNext(value)
+    // Call the function with the value (maybe event)
+    // to allow canceling it, and `return false`-ing
+    return fn && fn(value)
   }
 
   /* eslint-disable */


### PR DESCRIPTION
Although I am not sure myself if this is a good idea, as it feels to me stuff like cancelling the event should be done outside of this (wrapping it in another function?!). Still, it wasn’t much effort to make this, just in case you do want to merge it ;) Fixes #80