### PR TITLE
removing omit

### DIFF
--- a/src/packages/recompose/__tests__/mapPropsOnChange-test.js
+++ b/src/packages/recompose/__tests__/mapPropsOnChange-test.js
@@ -33,6 +33,8 @@ describe('mapPropsOnChange()', () => {
     renderIntoDocument(<StringConcat />)
 
     expect(omit(spy.getProps(), ['updateStrings'])).to.eql({
+      a: 'a',
+      b: 'b',
       c: 'c',
       foobar: 'ab',
       d: 'new'
@@ -44,6 +46,8 @@ describe('mapPropsOnChange()', () => {
     expect(mapSpy.callCount).to.equal(1)
 
     expect(omit(spy.getProps(), ['updateStrings', 'updateFoobar'])).to.eql({
+      a: 'a',
+      b: 'b',
       c: 'baz',
       foobar: 'ab',
       d: 'new'
@@ -51,6 +55,8 @@ describe('mapPropsOnChange()', () => {
 
     spy.getProps().updateStrings(strings => ({ ...strings, a: 'foo', 'b': 'bar', d: 'old' }))
     expect(omit(spy.getProps(), ['updateStrings', 'updateFoobar'])).to.eql({
+      a: 'foo',
+      b: 'bar',
       c: 'baz',
       foobar: 'foobar',
       d: 'new'

--- a/src/packages/recompose/mapPropsOnChange.js
+++ b/src/packages/recompose/mapPropsOnChange.js
@@ -1,6 +1,5 @@
 import { Component } from 'react'
 import pick from 'lodash/pick'
-import omit from 'lodash/omit'
 import shallowEqual from './shallowEqual'
 import createHelper from './createHelper'
 import createElement from './createElement'
@@ -22,7 +21,7 @@ const mapPropsOnChange = (depdendentPropKeys, propsMapper) => BaseComponent => {
 
     render() {
       return createElement(BaseComponent, {
-        ...omit(this.props, depdendentPropKeys),
+        ...this.props,
         ...this.computedProps
       })
     }


### PR DESCRIPTION
https://github.com/acdlite/recompose/pull/104#issuecomment-201820358

IMHO `omit` should be removed.

I'll explain why:

One of my most used construction with `mapPropsOnChange` was

```javascript
mapPropsOnChange(
  ['a', 'b', 'c'], 
  ({...props, a, b ,c}) => ({
    ...props,
    someResult: blabla(a,b,c)
  })
),
```

spread operator allows me to not lost `a,b,c` in the future, and reuse them again.

Now to make this work I can't use spread operator at all, because other props out of selection array i.e. ['a', 'b', 'c'] will be placed in `this.computedProps` so will be outdated. 

The code above after this [PR](https://github.com/acdlite/recompose/pull/104) now looks like

```javascript
mapPropsOnChange(
  ['a', 'b', 'c'], 
  ({a, b ,c}) => ({
    a,
    b,
    c,
    someResult: blabla(a,b,c)
  })
),
```

So every time I add property into selection array I need to add it into object to preserve. 

Removing `omit` will help a lot, I could just remove all that `...props`, and forget about property omitting logic in `mapPropsOnChange`

Also this simplify this component logic, I got a lot of questions from coworkers about this omitting functionality of `mapPropsOnChange`