### PR TITLE
depthEqual Proposal

### DIFF
--- a/src/packages/recompose/__tests__/depthEqual-test.js
+++ b/src/packages/recompose/__tests__/depthEqual-test.js
@@ -1,0 +1,130 @@
+import depthEqual from '../depthEqual'
+import { expect } from 'chai'
+
+// Adapted from https://github.com/rackt/react-redux/blob/master/test/utils/shallowEqual.spec.js
+describe('depthEqual()', () => {
+  it('returns true if arguments are equal', () => {
+    expect(depthEqual(expect, expect)).to.be.true
+    expect(depthEqual(expect, expect, 0)).to.be.true
+    expect(depthEqual(2, 2)).to.be.true
+    expect(depthEqual(2, 2, 0)).to.be.true
+  })
+
+  it('returns false if depth is 0 and !==', () => {
+    expect(
+      depthEqual(
+        { a: 1, b: 2, c: undefined },
+        { a: 1, b: 2, c: undefined },
+        0
+      )
+    ).to.be.false
+  })
+
+  it('returns true if depth is 1 and arguments fields are equal', () => {
+    expect(
+      depthEqual(
+        { a: 1, b: 2, c: undefined },
+        { a: 1, b: 2, c: undefined },
+        1
+      )
+    ).to.be.true
+
+    expect(
+      depthEqual(
+        { a: 1, b: 2, c: 3 },
+        { a: 1, b: 2, c: 3 }
+        // 1 should be default arg
+      )
+    ).to.be.true
+
+    const o = {}
+    expect(
+      depthEqual(
+        { a: 1, b: 2, c: o },
+        { a: 1, b: 2, c: o }
+      )
+    ).to.be.true
+  })
+
+  it('returns false if either argument is null or undefined', () => {
+    expect(
+      depthEqual(null, { a: 1, b: 2 })
+    ).to.be.false
+
+    expect(
+      depthEqual({ a: 1, b: 2 }, null)
+    ).to.be.false
+  })
+
+  it('returns false if first argument has too many keys', () => {
+    expect(
+      depthEqual(
+        { a: 1, b: 2, c: 3 },
+        { a: 1, b: 2 }
+      )
+    ).to.be.false
+  })
+
+  it('returns false if second argument has too many keys', () => {
+    expect(
+      depthEqual(
+        { a: 1, b: 2 },
+        { a: 1, b: 2, c: 3 }
+      )
+    ).to.be.false
+  })
+
+  it('returns false if arguments have different keys', () => {
+    expect(
+      depthEqual(
+        { a: 1, b: 2, c: undefined },
+        { a: 1, bb: 2, c: undefined }
+      )
+    ).to.be.false
+  })
+
+  it('returns true if depth is 2 and arguments have nested objects', () => {
+    expect(
+      depthEqual(
+        { a: { b: 1, c: 2 }, b: 2, c: undefined },
+        { a: { b: 1, c: 2 }, b: 2, c: undefined },
+        2
+      )
+    ).to.be.true
+
+    expect(
+      depthEqual(
+        { a: { b: 1, c: 2 }, b: 2, c: undefined },
+        { a: { b: 1, c: 2 }, b: 2, c: undefined }
+      )
+    ).to.be.false
+  })
+
+  it('returns false if depth is 2 and arguments have non-equal nested objects', () => {
+    expect(
+      depthEqual(
+        { a: { b: 1, c: 2 }, b: 2, c: undefined },
+        { a: { b: 1, c: 44 }, b: 2, c: undefined },
+        2
+      )
+    ).to.be.false
+  })
+
+  it('returns true if depth is 3 and arguments have doubly-nested objects', () => {
+    expect(
+      depthEqual(
+        { a: { b: 1, c: { d: 2 } }, e: 2, f: { g: 3 } },
+        { a: { b: 1, c: { d: 2 } }, e: 2, f: { g: 3 } },
+        3
+      )
+    ).to.be.true
+
+    expect(
+      depthEqual(
+        { a: { b: 1, c: { d: 2 } }, e: 2, f: { g: 3 } },
+        { a: { b: 1, c: { d: 2 } }, e: 2, f: { g: 3 } },
+        2
+      )
+    ).to.be.false
+  })
+})

--- a/src/packages/recompose/depthEqual.js
+++ b/src/packages/recompose/depthEqual.js
@@ -1,0 +1,35 @@
+// Adapted from https://github.com/facebook/fbjs/blob/master/src/core/shallowEqual.js
+
+const hasOwnProperty = Object.prototype.hasOwnProperty
+
+export default function depthEqual(objA, objB, depth = 1) {
+  if (objA === objB) {
+    return true
+  }
+
+  if (depth === 0 ||
+    typeof objA !== 'object' || objA === null ||
+    typeof objB !== 'object' || objB === null) {
+    return false
+  }
+
+  const keysA = Object.keys(objA)
+  const keysB = Object.keys(objB)
+
+  if (keysA.length !== keysB.length) {
+    return false
+  }
+
+  // Test for A's keys different from B.
+  const bHasOwnProperty = hasOwnProperty.bind(objB)
+  for (let i = 0; i < keysA.length; i++) {
+    const aKey = keysA[i]
+    if (!bHasOwnProperty(aKey) ||
+      // recursively call depthEqual at the next level; depth 0 is === check
+      !depthEqual(objA[aKey], objB[aKey], depth - 1)) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/src/packages/recompose/shallowEqual.js
+++ b/src/packages/recompose/shallowEqual.js
@@ -1,31 +1,5 @@
-// Copied from https://github.com/facebook/fbjs/blob/master/src/core/shallowEqual.js
-
-const hasOwnProperty = Object.prototype.hasOwnProperty
+import depthEqual from './depthEqual'
 
 export default function shallowEqual(objA, objB) {
-  if (objA === objB) {
-    return true
-  }
-
-  if (typeof objA !== 'object' || objA === null ||
-      typeof objB !== 'object' || objB === null) {
-    return false
-  }
-
-  const keysA = Object.keys(objA)
-  const keysB = Object.keys(objB)
-
-  if (keysA.length !== keysB.length) {
-    return false
-  }
-
-  // Test for A's keys different from B.
-  const bHasOwnProperty = hasOwnProperty.bind(objB)
-  for (let i = 0; i < keysA.length; i++) {
-    if (!bHasOwnProperty(keysA[i]) || objA[keysA[i]] !== objB[keysA[i]]) {
-      return false
-    }
-  }
-
-  return true
+  return depthEqual(objA, objB, 1)
 }


### PR DESCRIPTION
**Proposal for a new `shouldComponent` helper called `depthEqual`**

I have a situation where I'd like to be able to efficiently pass nested object literals to a component, here's a contrived simple example:

```
<Point position={{x: this.state.pointX, y: this.state.pointY}} />
```

Ideally the `Point` component could have a `shouldComponentUpdate` method that would prevent re-rendering if `props.position.x` and `props.position.y` remained the same, even if the `props.position` reference changed. This is a bit difficult with the current API.

This PR adds a new function called `depthEqual` to the API, which is just like `shallowEqual` except that it allows you to pass a third argument `depth` which specifies how many nested object layers should be checked for reference equality. `depthEqual(a, b, 0)` is equivalent to `a === b`, and `depthEqual(a, b, 1)` is equivalent to `shallowEqual(a, b)`. The default depth argument is `1`.

This would allow the `Point` class to implement a `shouldComponentUpdate` like:

```
class Point extends React.Component {
  shouldComponentUpdate(nextProps) {
    return !depthEqual(this.props, nextProps, 2);
  }
}
```

Generally you would want to optimize performance by checking some props shallowly and some deeply, using something like `_.pick` and `_.omit`, but this is just a simple example. Hopefully you think this is useful - object literal props are an anti-pattern sometimes but I think they have legitimate use cases too.

A couple notes - I added a unit test but I couldn't get it to work using `import depthEqual from 'recompose'` like the other unit tests do. It seems like that syntax imports from the `npm install`ed version, how do you test your code in development? Do you `npm link` it to itself or something? I just used `../` syntax for now to get it to pass.

Also I updated `shallowEqual` to call `depthEqual` but left the existing unit tests in place, so there may be some duplication there. Feel free to clean some of these out if you think it's appropriate.

Thanks for taking a look!

-dan