### PR TITLE
add suport for previous pops on props change

### DIFF
--- a/src/packages/recompose/doOnReceiveProps.js
+++ b/src/packages/recompose/doOnReceiveProps.js
@@ -5,11 +5,11 @@ import createElement from './createElement'
 const doOnReceiveProps = callback => BaseComponent =>
   class extends Component {
     componentWillMount() {
-      callback(this.props)
+      callback(this.props, null)
     }
 
     componentWillReceiveProps(nextProps) {
-      callback(nextProps)
+      callback(nextProps, this.props)
     }
 
     render() {


### PR DESCRIPTION
this caused a problem for me when using recompose - i had to have access to existing props on the callback, and they were'nt there...