### PR TITLE
Add a test for mapPropsOnChange

### DIFF
--- a/src/packages/recompose/__tests__/mapPropsOnChange-test.js
+++ b/src/packages/recompose/__tests__/mapPropsOnChange-test.js
@@ -32,6 +32,7 @@ test('mapPropsOnChange maps subset of owner props to child props', t => {
   // Does not re-map for non-dependent prop updates
   updateStrings(strings => ({ ...strings, c: 'baz' }))
   t.is(div.prop('foobar'), 'ab')
+  t.is(div.prop('c'), 'baz')
   t.is(mapSpy.callCount, 1)
 
   updateStrings(strings => ({ ...strings, a: 'foo', 'b': 'bar' }))


### PR DESCRIPTION
This PR shows an unexpected behavior of `mapPropsOnChange`.

Please see #119