### PR TITLE
Use codecov instead of codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ script:
   - $(npm bin)/nyc $(npm bin)/babel-node scripts/batchTests.js
 after_script:
   - "CODECLIMATE_REPO_TOKEN=27125df6192d300baf67cd5f5eab6597c998256f4883b744a1055d0f0c18e608 codeclimate-test-reporter < coverage/lcov.info"
-  - "cat ./coverage/lcov.info | ./node_modules/.bin/codecov"
+  - "./node_modules/.bin/codecov"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ script:
   - $(npm bin)/nyc $(npm bin)/babel-node scripts/batchTests.js
 after_script:
   - "CODECLIMATE_REPO_TOKEN=27125df6192d300baf67cd5f5eab6597c998256f4883b744a1055d0f0c18e608 codeclimate-test-reporter < coverage/lcov.info"
-  - "./node_modules/.bin/codecov -f coverage/lcov.info"
+  - "./node_modules/.bin/nyc report --reporter=lcov && ./node_modules/.bin/codecov"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ script:
   - $(npm bin)/nyc $(npm bin)/babel-node scripts/batchTests.js
 after_script:
   - "CODECLIMATE_REPO_TOKEN=27125df6192d300baf67cd5f5eab6597c998256f4883b744a1055d0f0c18e608 codeclimate-test-reporter < coverage/lcov.info"
-  - "./node_modules/.bin/codecov"
+  - "./node_modules/.bin/codecov -f coverage/lcov.info"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.3.0",
     "chalk": "^1.1.1",
-    "codecov.io": "^0.1.6",
+    "codecov": "^1.0.1",
     "enzyme": "^2.2.0",
     "eslint": "^1.5.1",
     "eslint-config-airbnb": "0.0.9",


### PR DESCRIPTION
[`codecov.io`](https://github.com/cainus/codecov.io) is deprecating, so it might be better to switch to [`codecov`](https://github.com/codecov/codecov-node).