### PR TITLE
Pull in API changes from next branch

### DIFF
--- a/src/packages/rx-recompose/README.md
+++ b/src/packages/rx-recompose/README.md
@@ -3,7 +3,7 @@ rx-recompose
 
 [![npm version](https://img.shields.io/npm/v/recompose-relay.svg?style=flat-square)](https://www.npmjs.com/package/rx-recompose)
 
-[RxJS](https://github.com/ReactiveX/RxJS) utilities for [Recompose](https://github.com/acdlite/recompose).
+RxJS utilities for [Recompose](https://github.com/acdlite/recompose).
 
 ```
 npm install --save rx-recompose
@@ -12,7 +12,7 @@ npm install --save rx-recompose
 It turns out that much of the React Component API can be expressed in terms of observables:
 
 - Instead of `setState()`, combine multiple streams together.
-- Instead of `getInitialState()`, use `startWith()`.
+- Instead of `getInitialState()`, use `startWith()` or `concat()`.
 - Instead of `shouldComponentUpdate()`, use `distinctUntilChanged()`, `debounce()`, etc.
 
 Other benefits include:
@@ -22,68 +22,80 @@ Other benefits include:
 - Sideways data loading is trivial – just combine the props stream with an external stream.
 - Access to the full ecosystem of RxJS libraries.
 
-Examples to come.
-
 ## API
+
+### `createComponent()`
+
+```js
+createComponent(
+  propsToReactNode: (props$: Observable<object>) => Observable<ReactNode>
+): ReactComponent
+```
+
+Creates a React component by mapping an observable stream of props to a stream of React nodes (vdom).
+
+You can think of `propsToReactNode` as a function `f` such that
+
+```js
+const vdom$ = f(props$)
+```
+
+where `props$` is a stream of props and `vdom$` is a stream of React nodes. This formulation similar to the popular notion of React views as a function, often communicated as
+
+```
+v = f(d)
+```
+
+See below for a full example.
 
 ### `observeProps()`
 
 ```js
 observeProps(
-  mapPropsStream: (props$: Observable) => Observable | { [propKey: string]: Observable },
+  ownerPropsToChildProps: (props$: Observable<object>) => Observable<object>,
   BaseComponent: ReactElementType
-): ReactElementType
+): ReactComponent
 ```
 
-Maps an observable stream of owner props to a stream of child props, or to an object of observables.
+A higher-order component version of `createComponent()` — accepts a function that maps an observable stream of owner props to a stream of child props, rather than directly to a stream of React nodes. The child props are then passed to a base component.
 
-In the second form, an object of streams is turned into an stream of objects. To illustrate, the following two `mapPropsStream()` functions are equivalent:
-
-```js
-const mapPropsStream1 = () => Observable.just({ a, b, c }),
-
-// Same as
-const mapPropsStream2 = () => ({
-  a: Observable.just(a),
-  b: Observable.just(b),
-  c: Observable.just(c)
-})
-```
-
-The second form is often more convenient because it avoids the need for `Observable.combineLatest()`, but note that it is also more limiting: you must explicitly declare every prop that is passed to the base component. There's no way to pass through arbitrary props from the owner. For full control over the stream of props, use the first form.
+You may want to use this version to interoperate with other Recompose higher-order component helpers.
 
 ### `createEventHandler()`
 
 ```js
-createEventHandler(): Function & Subject
+createEventHandler<T>(): {
+  handler: (value: T) => void
+  stream: Observable<T>,
+}
 ```
 
-Creates a Subject that is also a function. When called, the subject emits a new value. This type of function is ideal for passing event handlers from `observeProps()`:
+Returns an object with properties `handler` and `stream`. `stream` is an observable sequence, and `handler` is a function that pushes new values onto the sequence. (This is akin to mailboxes in Elm.) Useful for creating event handlers like `onClick`.
+
+## Example
 
 ```js
-const Counter = observeProps(
-  props$ => {
-    const increment$ = createEventHandler()
-    const decrement$ = createEventHandler()
+import { createComponent, createEventHandler } from 'rx-recompose'
+import { Observable } from 'rx'
 
-    const count$ = Observable.merge(
-        increment$.map(() => 1),
-        decrement$.map(() => -1)
-      )
-      .startWith(0)
-      .scan((count, n) => count + n)
+const Counter = createComponent(props$ => {
+  const { handler: increment, stream: increment$ } = createEventHandler()
+  const { handler: decrement, stream: decrement$ } = createEventHandler()
+  const count$ = Observable.merge(
+      increment$.map(() => 1),
+      decrement$.map(() => -1)
+    )
+    .startWith(0)
+    .scan((count, n) => count + n, 0)
 
-    return {
-      increment: Observable.just(increment$),
-      decrement: Observable.just(decrement$),
-      count: count$
-    }
-  })
-  (({ count, decrement, increment, ...props }) => (
-    <div {...props}>
-      Count: {count}
-      <button onClick={increment}>+</button>
-      <button onClick={decrement}>-</button>
-    </div>
-  ))
+  return props$.combineLatest(
+    count$,
+    (props, count) =>
+      <div {...props}>
+        Count: {count}
+        <button onClick={increment}>+</button>
+        <button onClick={decrement}>-</button>
+      </div>
+  )
+})
 ```

--- a/src/packages/rx-recompose/README.md
+++ b/src/packages/rx-recompose/README.md
@@ -48,10 +48,10 @@ v = f(d)
 
 See below for a full example.
 
-### `observeProps()`
+### `mapPropsStream()`
 
 ```js
-observeProps(
+mapPropsStream(
   ownerPropsToChildProps: (props$: Observable<object>) => Observable<object>,
   BaseComponent: ReactElementType
 ): ReactComponent
@@ -60,6 +60,20 @@ observeProps(
 A higher-order component version of `createComponent()` — accepts a function that maps an observable stream of owner props to a stream of child props, rather than directly to a stream of React nodes. The child props are then passed to a base component.
 
 You may want to use this version to interoperate with other Recompose higher-order component helpers.
+
+```js
+const enhance = mapPropsStream(props$ => {
+  const timeElapsed$ = Observable.interval(1000).pluck('value')
+  props$.combineLatest(timeElapsed$, (props, timeElapsed) => ({
+    ...props,
+    timeElapsed
+  }))
+})
+
+const Timer = enhance(({ timeElapsed }) =>
+  <div>Time elapsed: {timeElapsed}</div>
+)
+```
 
 ### `createEventHandler()`
 
@@ -79,7 +93,7 @@ import { createComponent, createEventHandler } from 'rx-recompose'
 import { Observable } from 'rx'
 
 const Counter = createComponent(props$ => {
-  const { handler: increment, stream: increment$ } = createEventHandler()
+  const { mapPropsStream: increment, stream: increment$ } = createEventHandler()
   const { handler: decrement, stream: decrement$ } = createEventHandler()
   const count$ = Observable.merge(
       increment$.map(() => 1),

--- a/src/packages/rx-recompose/__tests__/createEventHandler-test.js
+++ b/src/packages/rx-recompose/__tests__/createEventHandler-test.js
@@ -3,12 +3,12 @@ import { createEventHandler } from '../'
 
 test('createEventHandler creates a subject that broadcasts new values when called as a function', t => {
   const result = []
-  const eventHandler = createEventHandler()
-  const subscription = eventHandler.subscribe(v => result.push(v))
+  const { stream, handler } = createEventHandler()
+  const subscription = stream.subscribe(v => result.push(v))
 
-  eventHandler(1)
-  eventHandler(2)
-  eventHandler(3)
+  handler(1)
+  handler(2)
+  handler(3)
 
   subscription.dispose()
   t.deepEqual(result, [1, 2, 3])

--- a/src/packages/rx-recompose/__tests__/mapPropsStream-test.js
+++ b/src/packages/rx-recompose/__tests__/mapPropsStream-test.js
@@ -3,11 +3,11 @@ import React from 'react'
 import { Observable, Subject } from 'rx'
 import { withState, compose, branch } from 'recompose'
 import identity from 'lodash/identity'
-import { observeProps, createEventHandler } from '../'
+import { mapPropsStream, createEventHandler } from '../'
 import { mount, shallow } from 'enzyme'
 
-test('maps a stream of owner props to a stream of child props', t => {
-  const SmartButton = observeProps(props$ => {
+test('mapPropsStream maps a stream of owner props to a stream of child props', t => {
+  const SmartButton = mapPropsStream(props$ => {
     const { handler: onClick, stream: increment$ } = createEventHandler()
     const count$ = increment$
       .startWith(0)
@@ -20,7 +20,7 @@ test('maps a stream of owner props to a stream of child props', t => {
     }))
   })('button')
 
-  t.is(SmartButton.displayName, 'observeProps(button)')
+  t.is(SmartButton.displayName, 'mapPropsStream(button)')
 
   const button = mount(<SmartButton pass="through" />).find('button')
 
@@ -32,8 +32,8 @@ test('maps a stream of owner props to a stream of child props', t => {
   t.is(button.prop('pass'), 'through')
 })
 
-test('works on initial render', t => {
-  const SmartButton = observeProps(props$ => {
+test('mapPropsStream works on initial render', t => {
+  const SmartButton = mapPropsStream(props$ => {
     const { handler: onClick, stream: increment$ } = createEventHandler()
     const count$ = increment$
       .startWith(0)
@@ -52,8 +52,8 @@ test('works on initial render', t => {
   t.is(button.prop('pass'), 'through')
 })
 
-test('receives prop updates', t => {
-  const SmartButton = observeProps(props$ => {
+test('mapPropsStream receives prop updates', t => {
+  const SmartButton = mapPropsStream(props$ => {
     const { handler: onClick, stream: increment$ } = createEventHandler()
     const count$ = increment$
       .startWith(0)
@@ -76,7 +76,7 @@ test('receives prop updates', t => {
   t.is(button.prop('label'), 'Current count')
 })
 
-test('unsubscribes before unmounting', t => {
+test('mapPropsStream unsubscribes before unmounting', t => {
   const { handler: onClick, stream: increment$ } = createEventHandler()
   let count = 0
 
@@ -84,7 +84,7 @@ test('unsubscribes before unmounting', t => {
     withState('observe', 'updateObserve', false),
     branch(
       props => props.observe,
-      observeProps(() =>
+      mapPropsStream(() =>
         increment$
           .do(() => count += 1)
           .map(() => ({}))
@@ -107,9 +107,9 @@ test('unsubscribes before unmounting', t => {
   t.is(count, 2)
 })
 
-test('renders null until stream of props emits value', t => {
+test('mapPropsStream renders null until stream of props emits value', t => {
   const props$ = new Subject()
-  const Container = observeProps(() => props$)('div')
+  const Container = mapPropsStream(() => props$)('div')
   const wrapper = mount(<Container />)
 
   t.false(wrapper.some('div'))

--- a/src/packages/rx-recompose/__tests__/observeProps-test.js
+++ b/src/packages/rx-recompose/__tests__/observeProps-test.js
@@ -8,14 +8,14 @@ import { mount, shallow } from 'enzyme'
 
 test('maps a stream of owner props to a stream of child props', t => {
   const SmartButton = observeProps(props$ => {
-    const increment$ = createEventHandler()
+    const { handler: onClick, stream: increment$ } = createEventHandler()
     const count$ = increment$
       .startWith(0)
       .scan(total => total + 1)
 
     return Observable.combineLatest(props$, count$, (props, count) => ({
       ...props,
-      onClick: increment$,
+      onClick,
       count
     }))
   })('button')
@@ -34,14 +34,14 @@ test('maps a stream of owner props to a stream of child props', t => {
 
 test('works on initial render', t => {
   const SmartButton = observeProps(props$ => {
-    const increment$ = createEventHandler()
+    const { handler: onClick, stream: increment$ } = createEventHandler()
     const count$ = increment$
       .startWith(0)
       .scan(total => total + 1)
 
     return Observable.combineLatest(props$, count$, (props, count) => ({
       ...props,
-      onClick: increment$,
+      onClick,
       count
     }))
   })('button')
@@ -54,14 +54,14 @@ test('works on initial render', t => {
 
 test('receives prop updates', t => {
   const SmartButton = observeProps(props$ => {
-    const increment$ = createEventHandler()
+    const { handler: onClick, stream: increment$ } = createEventHandler()
     const count$ = increment$
       .startWith(0)
       .scan(total => total + 1)
 
     return Observable.combineLatest(props$, count$, (props, count) => ({
       ...props,
-      onClick: increment$,
+      onClick,
       count
     }))
   })('button')
@@ -77,7 +77,7 @@ test('receives prop updates', t => {
 })
 
 test('unsubscribes before unmounting', t => {
-  const increment$ = createEventHandler()
+  const { handler: onClick, stream: increment$ } = createEventHandler()
   let count = 0
 
   const Container = compose(
@@ -98,12 +98,12 @@ test('unsubscribes before unmounting', t => {
 
   t.is(count, 0)
   updateObserve(true) // Mount component
-  increment$()
+  onClick()
   t.is(count, 1)
-  increment$()
+  onClick()
   t.is(count, 2)
   updateObserve(false) // Unmount component
-  increment$()
+  onClick()
   t.is(count, 2)
 })
 

--- a/src/packages/rx-recompose/createComponent.js
+++ b/src/packages/rx-recompose/createComponent.js
@@ -1,0 +1,58 @@
+import { Component } from 'react'
+import { Observable } from 'rx'
+
+const createComponent = propsToVdom =>
+  class RxComponent extends Component {
+    state = {};
+
+    // Stream of props
+    props$ = Observable.create(observer => {
+      this.propsObserver = observer
+      this.propsObserver.onNext(this.props)
+    });
+
+    // Stream of vdom
+    vdom$ = propsToVdom(this.props$);
+
+    didReceiveVdom = false;
+
+    // Keep track of whether the component has mounted
+    componentHasMounted = false;
+
+    componentWillMount() {
+      // Subscribe to child prop changes so we know when to re-render
+      this.subscription = this.vdom$.subscribe(
+        vdom => {
+          this.didReceiveVdom = true
+          return !this.componentHasMounted
+            ? this.state = { vdom }
+            : this.setState({ vdom })
+        }
+      )
+    }
+
+    componentDidMount() {
+      this.componentHasMounted = true
+    }
+
+    componentWillReceiveProps(nextProps) {
+      // Receive new props from the owner
+      this.propsObserver.onNext(nextProps)
+    }
+
+    shouldComponentUpdate(nextProps, nextState) {
+      return nextState.vdom !== this.state.vdom
+    }
+
+    componentWillUnmount() {
+      // Clean-up subscription before un-mounting
+      this.subscription.dispose()
+    }
+
+    render() {
+      if (!this.didReceiveVdom) return null
+      return this.state.vdom
+    }
+  }
+
+export default createComponent

--- a/src/packages/rx-recompose/createEventHandler.js
+++ b/src/packages/rx-recompose/createEventHandler.js
@@ -1,21 +1,18 @@
-import { Subject } from 'rx'
+import { Observable } from 'rx'
 
-// Idea and implementation borrowed from
-// https://github.com/fdecampredon/rx-react
 const createEventHandler = () => {
-  function subject(value) {
-    subject.onNext(value)
+  const observers = []
+  const stream = Observable.create(observer => {
+    observers.push(observer)
+    return () => {
+      const i = observers.indexOf(observer)
+      observers.splice(i, 1)
+    }
+  })
+  return {
+    handler: value => observers.forEach(observer => observer.onNext(value)),
+    stream
   }
-
-  /* eslint-disable */
-  for (let key in Subject.prototype) {
-  /* eslint-enable */
-    subject[key] = Subject.prototype[key]
-  }
-
-  Subject.call(subject)
-
-  return subject
 }
 
 export default createEventHandler

--- a/src/packages/rx-recompose/index.js
+++ b/src/packages/rx-recompose/index.js
@@ -1,2 +1,2 @@
-export observeProps from './observeProps'
+export mapPropsStream from './mapPropsStream'
 export createEventHandler from './createEventHandler'

--- a/src/packages/rx-recompose/mapPropsStream.js
+++ b/src/packages/rx-recompose/mapPropsStream.js
@@ -3,7 +3,7 @@ import createHelper from 'recompose/createHelper'
 import createComponent from './createComponent'
 import { Observable } from 'rx'
 
-const observeProps = ownerPropsToChildProps => BaseComponent =>
+const mapPropsStream = ownerPropsToChildProps => BaseComponent =>
   createComponent(ownerProps$ =>
     Observable.create(observer => {
       const subscription = ownerPropsToChildProps(ownerProps$).subscribe(
@@ -17,4 +17,4 @@ const observeProps = ownerPropsToChildProps => BaseComponent =>
     })
   )
 
-export default createHelper(observeProps, 'observeProps')
+export default createHelper(mapPropsStream, 'mapPropsStream')

--- a/src/packages/rx-recompose/observeProps.js
+++ b/src/packages/rx-recompose/observeProps.js
@@ -1,77 +1,20 @@
-import { Component } from 'react'
-import { Observable, Subject } from 'rx'
-import isPlainObject from 'lodash/isPlainObject'
 import createElement from 'recompose/createElement'
 import createHelper from 'recompose/createHelper'
+import createComponent from './createComponent'
+import { Observable } from 'rx'
 
-// Turns an object of streams into a stream of objects
-const objectToPropSequence = object => {
-  const propKeys = Object.keys(object)
-  const propSequences = propKeys.map(key => object[key].startWith(undefined))
-  return Observable.combineLatest(
-    ...propSequences,
-    (...propValues) => propKeys.reduce((props, key, i) => {
-      props[key] = propValues[i]
-      return props
-    }, {})
-  )
-}
-
-const observeProps = propsSequenceMapper => BaseComponent =>
-  class extends Component {
-    state = {};
-
-    // Subject that receives props from owner
-    receiveOwnerProps$ = new Subject();
-
-    // Stream of owner props
-    ownerProps$ = this.receiveOwnerProps$.startWith(this.props);
-
-    // Stream of child props
-    childProps$ = (val => isPlainObject(val)
-      ? objectToPropSequence(val)
-      : val
-    )(propsSequenceMapper(this.ownerProps$));
-
-    // Keep track of whether the component has mounted
-    componentHasMounted = false;
-
-    componentWillMount() {
-      // Subscribe to child prop changes so we know when to re-render
-      this.subscription = this.childProps$.subscribe(childProps => {
-        this.didEmitProps = true
-        if (!this.componentHasMounted) {
-          this.state = { childProps }
-        } else {
-          this.setState({ childProps })
+const observeProps = ownerPropsToChildProps => BaseComponent =>
+  createComponent(ownerProps$ =>
+    Observable.create(observer => {
+      const subscription = ownerPropsToChildProps(ownerProps$).subscribe(
+        childProps => {
+          return observer.next(
+            createElement(BaseComponent, childProps)
+          )
         }
-      })
-    }
-
-    componentDidMount() {
-      this.componentHasMounted = true
-    }
-
-    componentWillReceiveProps(nextProps) {
-      // Receive new props from the owner
-      this.receiveOwnerProps$.onNext(nextProps)
-    }
-
-    shouldComponentUpdate(nextProps, nextState) {
-      return nextState.childProps !== this.state.childProps
-    }
-
-    componentWillUnmount() {
-      // Clean-up subscription before un-mounting
-      this.subscription.dispose()
-    }
-
-    render() {
-      if (!this.didEmitProps) {
-        return null
-      }
-      return createElement(BaseComponent, this.state.childProps)
-    }
-  }
+      )
+      return () => subscription.dispose()
+    })
+  )
 
 export default createHelper(observeProps, 'observeProps')


### PR DESCRIPTION
The `next` branch has some nice improvements, but they won't be released until RxJS 5 is finalized. In the meantime, we should port those improvements over to master.

- [x] Add `createComponent`
- [x] `createEventHandler` returns a separate stream and handler, like Elm mailboxes.
- [x] Remove support for object-of-streams return value.
- [x] Rename `observeProps` to `mapPropsStream` (not part of `next` branch, but let's go ahead and do this now, anyway).