### PR TITLE
Small tidy up `withHandlers` usage example

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -151,11 +151,10 @@ const enhance = compose(
   })
 )
 
-const Form = enhance(({ value, onChange, onSubmit }) =>
+const Form = enhance(({ onChange, onSubmit, value }) =>
   <form onSubmit={onSubmit}>
-    <label>Value
-      <input type="text" value={value} onChange={onChange} />
-    </label>
+    <input type="text" onChange={onChange} />
+    <p>Value: {value}</p>
   </form>
 )
 ```


### PR DESCRIPTION
- removed `<label>` since not necessary
- removed 'value' prop from `<input />` since initial state is empty 
- render value to demo state