### PR TITLE
changed flattenProp hoc it does not omit flattened prop

### DIFF
--- a/src/packages/recompose/__tests__/flattenProp-test.js
+++ b/src/packages/recompose/__tests__/flattenProp-test.js
@@ -7,11 +7,18 @@ test('flattenProps flattens an object prop and spreads it into the top-level pro
   const Counter = flattenProp('state')('div')
   t.is(Counter.displayName, 'flattenProp(div)')
 
-  const wrapper = shallow(
+  let wrapper = shallow(
     <Counter pass="through" state={{ counter: 1 }} />
   )
 
   t.true(wrapper.equals(
-    <div pass="through" counter={1} />
+    <div pass="through" state={{ counter: 1 }} counter={1} />
+  ))
+
+  wrapper = shallow(
+    <Counter pass="through" state={{ state: 1 }} />
+  )
+  t.true(wrapper.equals(
+    <div pass="through" state={1} />
   ))
 })

--- a/src/packages/recompose/__tests__/flattenProp-test.js
+++ b/src/packages/recompose/__tests__/flattenProp-test.js
@@ -7,7 +7,7 @@ test('flattenProps flattens an object prop and spreads it into the top-level pro
   const Counter = flattenProp('state')('div')
   t.is(Counter.displayName, 'flattenProp(div)')
 
-  let wrapper = shallow(
+  const wrapper = shallow(
     <Counter pass="through" state={{ counter: 1 }} />
   )
 
@@ -15,9 +15,10 @@ test('flattenProps flattens an object prop and spreads it into the top-level pro
     <div pass="through" state={{ counter: 1 }} counter={1} />
   ))
 
-  wrapper = shallow(
-    <Counter pass="through" state={{ state: 1 }} />
-  )
+  wrapper.setProps({
+    pass: 'through',
+    state: { state: 1 }
+  })
   t.true(wrapper.equals(
     <div pass="through" state={1} />
   ))

--- a/src/packages/recompose/flattenProp.js
+++ b/src/packages/recompose/flattenProp.js
@@ -1,4 +1,3 @@
-import omit from './utils/omit'
 import createHelper from './createHelper'
 import createEagerFactory from './createEagerFactory'
 
@@ -6,7 +5,7 @@ const flattenProp = propName => BaseComponent => {
   const factory = createEagerFactory(BaseComponent)
   return props => (
     factory({
-      ...omit(props, [propName]),
+      ...props,
       ...props[propName]
     })
   )


### PR DESCRIPTION
Connects #190 

There is one issue that has not resolved. If the flatten prop has a key with the same name of the prop, it will be overwritten. As shown on second test case of `flattenProp-test.js`.

Any suggestion on solving this?