### PR TITLE
Add identity function to example code

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -308,6 +308,8 @@ Takes a component and returns a higher-order component version of that component
 This is useful in combination with another helper that expects a higher-order component, like `branch()`:
 
 ```js
+const identity = t => t
+
 // `hasLoaded()` is a function that returns whether or not the the component
 // has all the props it needs
 const spinnerWhileLoading = hasLoaded =>


### PR DESCRIPTION
Adding `identity` function on the `branch` example code.

I got confused for `branch` function's document and example and I could understood this with issue https://github.com/acdlite/recompose/issues/109#issuecomment-214923584.

