### PR TITLE
Fix mapPropsStream applying transforms twice

### DIFF
--- a/src/packages/recompose/__tests__/mapPropsStream-test.js
+++ b/src/packages/recompose/__tests__/mapPropsStream-test.js
@@ -1,11 +1,11 @@
 import test from 'ava'
 import React from 'react'
 import setObservableConfig from '../setObservableConfig'
-import rxjsConfig from '../rxjsObservableConfig'
+import rxjs4Config from '../rxjs4ObservableConfig'
 import { mount } from 'enzyme'
 import { mapPropsStream } from '../'
 
-setObservableConfig(rxjsConfig)
+setObservableConfig(rxjs4Config)
 
 // Most of mapPropsStream's functionality is covered by componentFromStream
 test('mapPropsStream creates a higher-order component from a stream', t => {

--- a/src/packages/recompose/componentFromStream.js
+++ b/src/packages/recompose/componentFromStream.js
@@ -1,16 +1,16 @@
 import { Component } from 'react'
 import { createChangeEmitter } from 'change-emitter'
 import $$observable from 'symbol-observable'
-import { fromESObservable, toESObservable } from './setObservableConfig'
+import { config as globalConfig } from './setObservableConfig'
 
-const componentFromStream = propsToVdom =>
+export const componentFromStreamWithConfig = config => propsToVdom =>
   class ComponentFromStream extends Component {
     state = { vdom: null };
 
     propsEmitter = createChangeEmitter();
 
     // Stream of props
-    props$ = fromESObservable({
+    props$ = config.fromESObservable({
       subscribe: observer => {
         const unsubscribe = this.propsEmitter.listen(
           props => observer.next(props)
@@ -23,7 +23,7 @@ const componentFromStream = propsToVdom =>
     });
 
     // Stream of vdom
-    vdom$ = toESObservable(propsToVdom(this.props$));
+    vdom$ = config.toESObservable(propsToVdom(this.props$));
 
     componentWillMount() {
       // Subscribe to child prop changes so we know when to re-render
@@ -53,5 +53,7 @@ const componentFromStream = propsToVdom =>
       return this.state.vdom
     }
   }
+
+const componentFromStream = componentFromStreamWithConfig(globalConfig)
 
 export default componentFromStream

--- a/src/packages/recompose/createEventHandler.js
+++ b/src/packages/recompose/createEventHandler.js
@@ -1,10 +1,10 @@
 import $$observable from 'symbol-observable'
 import { createChangeEmitter } from 'change-emitter'
-import { fromESObservable } from './setObservableConfig'
+import { config as globalConfig } from './setObservableConfig'
 
-const createEventHandler = () => {
+export const createEventHandlerWithConfig = config => () => {
   const emitter = createChangeEmitter()
-  const stream = fromESObservable({
+  const stream = config.fromESObservable({
     subscribe(observer) {
       const unsubscribe = emitter.listen(value => observer.next(value))
       return { unsubscribe }
@@ -18,5 +18,7 @@ const createEventHandler = () => {
     stream
   }
 }
+
+const createEventHandler = createEventHandlerWithConfig(globalConfig)
 
 export default createEventHandler

--- a/src/packages/recompose/mapPropsStream.js
+++ b/src/packages/recompose/mapPropsStream.js
@@ -1,24 +1,35 @@
 import $$observable from 'symbol-observable'
 import createEagerFactory from './createEagerFactory'
 import createHelper from './createHelper'
-import componentFromStream from './componentFromStream'
-import { toESObservable } from './setObservableConfig'
+import { componentFromStreamWithConfig } from './componentFromStream'
+import { config as globalConfig } from './setObservableConfig'
 
-const mapPropsStream = transform => BaseComponent => {
-  const factory = createEagerFactory(BaseComponent)
-  return componentFromStream(ownerProps$ => ({
-    subscribe(observer) {
-      const subscription = toESObservable(transform(ownerProps$)).subscribe({
-        next: childProps => observer.next(factory(childProps))
-      })
-      return {
-        unsubscribe: () => subscription.unsubscribe()
+const identity = t => t
+const componentFromStream = componentFromStreamWithConfig({
+  fromESObservable: identity,
+  toESObservable: identity
+})
+
+export const mapPropsStreamWithConfig = config => transform =>
+  BaseComponent => {
+    const factory = createEagerFactory(BaseComponent)
+    const { fromESObservable, toESObservable } = config
+    return componentFromStream(props$ => ({
+      subscribe(observer) {
+        const subscription = toESObservable(transform(fromESObservable(props$)))
+          .subscribe({
+            next: childProps => observer.next(factory(childProps))
+          })
+        return {
+          unsubscribe: () => subscription.unsubscribe()
+        }
+      },
+      [$$observable]() {
+        return this
       }
-    },
-    [$$observable]() {
-      return this
-    }
-  }))
-}
+    }))
+  }
+
+const mapPropsStream = mapPropsStreamWithConfig(globalConfig)
 
 export default createHelper(mapPropsStream, 'mapPropsStream')

--- a/src/packages/recompose/setObservableConfig.js
+++ b/src/packages/recompose/setObservableConfig.js
@@ -1,20 +1,21 @@
-let config = {
+let _config = {
   fromESObservable: null,
   toESObservable: null
 }
 
-export const fromESObservable = observable =>
-  typeof config.fromESObservable === 'function'
-    ? config.fromESObservable(observable)
-    : observable
-
-export const toESObservable = stream =>
-  typeof config.toESObservable === 'function'
-    ? config.toESObservable(stream)
-    : stream
-
 const configureObservable = c => {
-  config = c
+  _config = c
+}
+
+export const config = {
+  fromESObservable: observable =>
+    typeof _config.fromESObservable === 'function'
+      ? _config.fromESObservable(observable)
+      : observable,
+  toESObservable: stream =>
+    typeof _config.toESObservable === 'function'
+      ? _config.toESObservable(stream)
+      : stream
 }
 
 export default configureObservable


### PR DESCRIPTION
Because mapPropsStream composes componentFromStream, the global observable transforms were being applied twice. We'll fix by exporting a factory version of each observable util (including componentFromStream) that allows you opt-out of the global transform.

This was not caught earlier because the tests for mapPropsStream use RxJS 5, which is not affected by double transforms because its observables are ES observables, anyway. To protect against regressions, we'll switch to testing with RxJS4 for now.

Keeping the new factory functions private for now so this can go out as a patch release.