### PR TITLE
Fix a react-unknown-props warning

### DIFF
--- a/src/packages/recompose/__tests__/withHandlers-test.js
+++ b/src/packages/recompose/__tests__/withHandlers-test.js
@@ -107,7 +107,7 @@ test.serial('withHandlers warns if handler is not a higher-order function', t =>
     onClick: () => {}
   })('button')
 
-  const wrapper = mount(<Button foo="bar" />)
+  const wrapper = mount(<Button />)
   const button = wrapper.find('button')
 
   t.throws(() => button.simulate('click'), /undefined/)


### PR DESCRIPTION
The `react-unknown-props` warning occurs before `withHandler`'s warning, so the test is failed.

```
   1. withHandlers-test › withHandlers warns if handler is not a higher-order function

  t.is(error.firstCall.args[0], 'withHandlers(): Expected a map of higher-order functions. Refer to ' + 'the docs for more info.')
                           |
                           "Warning: Unknown prop `foo` on <button> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop\n    in button (created by withHandlers(button))\n    in withHandlers(button) (created by Unknown)\n    in Unknown"
```

This is a quick fix for helping CI back to normal. There are still `react-unknown-props` warnings in other tests.