### PR TITLE
Update dependentPropKeys to shouldMapOrKeys in API docs.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -120,7 +120,7 @@ withPropsOnChange(
 ): HigherOrderComponent
 ```
 
-Like `withProps()`, except the new props are only created when one of the owner props specified by `dependentPropKeys` changes. This helps ensure that expensive computations inside `createProps()` are only executed when necessary.
+Like `withProps()`, except the new props are only created when one of the owner props specified by `shouldMapOrKeys` changes. This helps ensure that expensive computations inside `createProps()` are only executed when necessary.
 
 Instead of an array of prop keys, the first parameter can also be a function that returns a boolean, given the current props and the next props. This allows you to customize when `createProps()` should be called.
 


### PR DESCRIPTION
The signature of `withPropsOnChange` contained the new name `shouldMapOrKeys`, while the explanation referred `dependentPropKeys`.