### PR TITLE
Add partial and partialProps high order components

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -56,6 +56,7 @@ const PureComponent = pure(BaseComponent)
   + [`lifecycle()`](#lifecycle)
   + [`toClass()`](#toclass)
   + [`partial()`](#partial)
+  + [`partialWithProps()`](#partialWithProps)
 * [Static property helpers](#static-property-helpers)
   + [`setStatic()`](#setstatic)
   + [`setPropTypes()`](#setproptypes)
@@ -482,6 +483,17 @@ partial(
 ```
 
 Replaces original `props[functionName]` function to function with prepended arguments.
+
+### `partialWithProps()`
+
+```js
+partialWithProps(
+  functionName: string,
+  propArgNames: Array<string>
+)
+```
+
+Replaces original `props[functionName]` function to function with prepended arguments from props.
 
 ### `setStatic()`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -55,6 +55,7 @@ const PureComponent = pure(BaseComponent)
   + [`getContext()`](#getcontext)
   + [`lifecycle()`](#lifecycle)
   + [`toClass()`](#toclass)
+  + [`partial()`](#partial)
 * [Static property helpers](#static-property-helpers)
   + [`setStatic()`](#setstatic)
   + [`setPropTypes()`](#setproptypes)
@@ -470,6 +471,17 @@ If the base component is already a class, it returns the given component.
 ## Static property helpers
 
 These functions look like higher-order component helpers — they are curried and component-last. However, rather than returning a new component, they mutate the base component by setting or overriding a static property.
+
+### `partial()`
+
+```js
+partial(
+  functionName: string,
+  funcArgs: Array
+)
+```
+
+Replaces original `props[functionName]` function to function with prepended arguments.
 
 ### `setStatic()`
 

--- a/src/packages/recompose/__tests__/partial-test.js
+++ b/src/packages/recompose/__tests__/partial-test.js
@@ -1,0 +1,45 @@
+import test from 'ava'
+import React from 'react'
+import { mount } from 'enzyme'
+import sinon from 'sinon'
+
+import { partial } from '../'
+
+test('partial with passed values', t => {
+  const Component = partial('foo', [1, 'a'])(({ foo }) => (
+    <button onClick={foo}>click</button>
+  ))
+
+  const foo = sinon.spy()
+
+  const wrapper = mount(<Component {...{ foo }} />)
+
+  wrapper.find('button').simulate('click')
+
+  t.true(foo.calledWith(1, 'a'))
+})
+
+test('partial with passed and extra values', t => {
+  const Component = partial('foo', [1, 'a'])(({ foo }) => (
+    <button onClick={() => foo('b', 3)}>click</button>
+  ))
+
+  const foo = sinon.spy()
+
+  const wrapper = mount(<Component {...{ foo }} />)
+
+  wrapper.find('button').simulate('click')
+
+  t.true(foo.calledWith(1, 'a'))
+})
+
+test('partial props[functionName] should be a function', t => {
+  const Component = partial('foo', [1, 'a'])(({ foo }) => (
+    <button onClick={foo}>click</button>
+  ))
+
+
+  const wrapper = mount(<Component foo="asdf" />)
+
+  t.throws(() => wrapper.find('button').simulate('click'))
+})

--- a/src/packages/recompose/__tests__/partialWithProps-test.js
+++ b/src/packages/recompose/__tests__/partialWithProps-test.js
@@ -1,0 +1,48 @@
+import test from 'ava'
+import React from 'react'
+import { mount } from 'enzyme'
+import sinon from 'sinon'
+
+import { partialWithProps } from '../'
+
+test('partialWithProps with passed props', t => {
+  const Component = partialWithProps('foo', ['firstProp', 'secondProp'])(
+    ({ foo }) => <button onClick={foo}>click</button>
+  )
+
+  const foo = sinon.spy()
+
+  const wrapper = mount(<Component foo={foo} firstProp={1} secondProp="asd" />)
+
+  wrapper.find('button').simulate('click')
+
+  t.true(
+    foo.calledWith(1, 'asd')
+  )
+})
+
+test('partialWithProps with passes props and extra args', t => {
+  const Component = partialWithProps('foo', ['firstProp', 'secondProp'])(
+    ({ foo }) => <button onClick={() => foo('qwe', {})}>click</button>
+  )
+
+  const foo = sinon.spy()
+
+  const wrapper = mount(<Component foo={foo} firstProp={1} secondProp="asd" />)
+
+  wrapper.find('button').simulate('click')
+
+  t.true(
+    foo.calledWith(1, 'asd', 'qwe', {})
+  )
+})
+
+test('partialWithPrpos props[funcName] should be a function', t => {
+  const Component = partialWithProps('foo', ['firstProp', 'secondProp'])(
+    ({ foo }) => <button onClick={foo}>click</button>
+  )
+
+  const wrapper = mount(<Component foo={1} firstProp={3} secondProp="asd" />)
+
+  t.throws(() => wrapper.find('button').simulate('click'))
+})

--- a/src/packages/recompose/index.js
+++ b/src/packages/recompose/index.js
@@ -21,6 +21,7 @@ export getContext from './getContext'
 export lifecycle from './lifecycle'
 export toClass from './toClass'
 export partial from './partial'
+export partialWithProps from './partialWithProps'
 
 // Static property helpers
 export setStatic from './setStatic'

--- a/src/packages/recompose/index.js
+++ b/src/packages/recompose/index.js
@@ -20,6 +20,7 @@ export withContext from './withContext'
 export getContext from './getContext'
 export lifecycle from './lifecycle'
 export toClass from './toClass'
+export partial from './partial'
 
 // Static property helpers
 export setStatic from './setStatic'

--- a/src/packages/recompose/partial.js
+++ b/src/packages/recompose/partial.js
@@ -1,0 +1,19 @@
+import createHelper from './createHelper'
+import withHandlers from './withHandlers'
+
+function partial(functionName, funcArgs) {
+  return BaseComponent => withHandlers({
+    [functionName]: props => {
+      if (typeof props[functionName] !== 'function') {
+        const type = typeof props[functionName]
+        throw new Error(
+          `partial(): ${functionName} should be a function not ${type}`
+        )
+      }
+
+      return (...args) => props[functionName](...funcArgs, ...args)
+    }
+  })(BaseComponent)
+}
+
+export default createHelper(partial, 'partial')

--- a/src/packages/recompose/partial.js
+++ b/src/packages/recompose/partial.js
@@ -1,19 +1,17 @@
 import createHelper from './createHelper'
 import withHandlers from './withHandlers'
 
-function partial(functionName, funcArgs) {
-  return BaseComponent => withHandlers({
-    [functionName]: props => {
-      if (typeof props[functionName] !== 'function') {
-        const type = typeof props[functionName]
-        throw new Error(
-          `partial(): ${functionName} should be a function not ${type}`
-        )
-      }
-
-      return (...args) => props[functionName](...funcArgs, ...args)
+const partial = (functionName, funcArgs) => BaseComponent => withHandlers({
+  [functionName]: props => {
+    if (typeof props[functionName] !== 'function') {
+      const type = typeof props[functionName]
+      throw new Error(
+        `partial(): ${functionName} should be a function not ${type}`
+      )
     }
-  })(BaseComponent)
-}
+
+    return (...args) => props[functionName](...funcArgs, ...args)
+  }
+})(BaseComponent)
 
 export default createHelper(partial, 'partial')

--- a/src/packages/recompose/partialWithProps.js
+++ b/src/packages/recompose/partialWithProps.js
@@ -1,0 +1,22 @@
+import createHelper from './createHelper'
+import withHandlers from './withHandlers'
+
+const partialWithProps = (functionName, propArgNames) => BaseComponent => (
+  withHandlers({
+    [functionName]: props => {
+      if (typeof props[functionName] !== 'function') {
+        const type = typeof props[functionName]
+        throw new Error(
+          `partial(): ${functionName} should be a function not ${type}`
+        )
+      }
+
+      const funcArgs = propArgNames.map(item => props[item])
+
+      return (...args) => props[functionName](...funcArgs, ...args)
+    }
+  })(BaseComponent)
+)
+
+
+export default createHelper(partialWithProps, 'partialWithProps')


### PR DESCRIPTION
Hi all. 

Predefine arguments to passed function to component could be useful in various situations if we need to send token or update special entity. Of course we could use `withHandlers()` for it but to have special high order components looks good for it. 