### PR TITLE
Update recompose-relay peer dependencies

### DIFF
--- a/src/packages/recompose-relay/package.json
+++ b/src/packages/recompose-relay/package.json
@@ -18,8 +18,8 @@
     "lodash": "^4.0.0"
   },
   "peerDependencies": {
-    "recompose": "^0.17.0",
+    "recompose": ">= 0.17.0 < 1.0.0",
     "react": "^0.14.0 || ^15.0.0",
-    "react-relay": "^0.6.0"
+    "react-relay": ">= 0.6.0 < 1.0.0"
   }
 }


### PR DESCRIPTION
Seems like the peerdeps haven't been updated for a while and the caret flag doesn't work since we're in <1.0.0 (please correct me if I'm wrong)

Thanks!
