### PR TITLE
Update peer dependency for react-relay.

### DIFF
--- a/src/packages/recompose-relay/package.json
+++ b/src/packages/recompose-relay/package.json
@@ -20,6 +20,6 @@
   "peerDependencies": {
     "recompose": "^0.17.0",
     "react": "^0.14.0 || ^15.0.0",
-    "react-relay": "^0.6.0"
+    "react-relay": "^0.9.3"
   }
 }


### PR DESCRIPTION
This currently causes shrinkwrap to fail when used with the latest react-relay in the host repository.