### PR TITLE
Jest snapshot test example (not for merging)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,8 @@
   "parser": "babel-eslint",
   "env": {
     "browser": true,
-    "node": true
+    "node": true,
+    "jest": true,
   },
   "globals": {
     "sinon": true

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint src",
+    "jest-test": "jest",
     "test": "ava --concurrency=5",
     "test:watch": "npm run test -- --watch",
     "release": "babel-node scripts/release.js",
@@ -19,6 +20,7 @@
     "babel-cli": "^6.5.1",
     "babel-core": "^6.5.2",
     "babel-eslint": "^6.0.4",
+    "babel-jest": "^15.0.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-syntax-jsx": "^6.8.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
@@ -60,6 +62,7 @@
     "eslint-plugin-react": "^5.1.1",
     "globby": "^4.0.0",
     "gzip-size-cli": "^1.0.0",
+    "jest": "^15.1.1",
     "jsdom": "^8.4.0",
     "kefir": "^3.2.3",
     "most": "^0.19.7",
@@ -67,6 +70,7 @@
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",
+    "react-test-renderer": "^15.3.2",
     "readline-sync": "^1.2.21",
     "rimraf": "^2.4.3",
     "rx": "^4.1.0",
@@ -93,5 +97,9 @@
       "./testSetup"
     ],
     "babel": "inherit"
+  },
+  "jest": {
+    "verbose": true,
+    "testRegex": "(/__jest_tests__/.*js$)"
   }
 }

--- a/src/packages/recompose/__jest_tests__/__snapshots__/branch-test.js.snap
+++ b/src/packages/recompose/__jest_tests__/__snapshots__/branch-test.js.snap
@@ -1,0 +1,40 @@
+exports[`test branch defaults third argument to identity function 1`] = `
+<div
+  className="right">
+  Right
+</div>
+`;
+
+exports[`test branch tests props and applies one of two HoCs, for true and false 1`] = `
+<div>
+  <div
+    className="isBad">
+    false
+  </div>
+  <div
+    className="name">
+    Walter
+  </div>
+  <button
+    onClick={[Function onClick]}>
+    Toggle
+  </button>
+</div>
+`;
+
+exports[`test branch tests props and applies one of two HoCs, for true and false 2`] = `
+<div>
+  <div
+    className="isBad">
+    true
+  </div>
+  <div
+    className="name">
+    Heisenberg
+  </div>
+  <button
+    onClick={[Function onClick]}>
+    Toggle
+  </button>
+</div>
+`;

--- a/src/packages/recompose/__jest_tests__/branch-test.js
+++ b/src/packages/recompose/__jest_tests__/branch-test.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { branch, compose, withState, withProps } from '../'
+import renderer from 'react-test-renderer'
+
+it('branch tests props and applies one of two HoCs, for true and false', () => {
+  const SayMyName = compose(
+    withState('isBad', 'updateIsBad', false),
+    branch(
+      props => props.isBad,
+      withProps({ name: 'Heisenberg' }),
+      withProps({ name: 'Walter' })
+    )
+  )(({ isBad, name, updateIsBad }) =>
+    <div>
+      <div className="isBad">{isBad ? 'true' : 'false'}</div>
+      <div className="name">{name}</div>
+      <button onClick={() => updateIsBad(b => !b)}>Toggle</button>
+    </div>
+  )
+
+  expect(SayMyName.displayName).toBe('withState(branch(Component))')
+
+  const component = renderer.create(<SayMyName />)
+  const beforeClick = component.toJSON()
+  expect(beforeClick).toMatchSnapshot()
+
+  beforeClick.children[2].props.onClick()
+  const afterClick = component.toJSON()
+  expect(afterClick).toMatchSnapshot()
+})
+
+
+it('branch defaults third argument to identity function', () => {
+  const Left = () => <div className="left">Left</div>
+  const Right = () => <div className="right">Right</div>
+
+  const BranchedComponent = branch(
+    () => false,
+    () => props => <Left {...props} />
+  )(Right)
+
+  const component = renderer.create(<BranchedComponent />)
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/packages/recompose/branch.js
+++ b/src/packages/recompose/branch.js
@@ -4,7 +4,7 @@ import createEagerFactory from './createEagerFactory'
 
 const identity = component => component
 
-const branch = (test, left, right = identity) => BaseComponent =>
+const branch = (test, left, right) => BaseComponent =>
   class extends React.Component {
     LeftComponent = null;
     RightComponent = null;
@@ -21,7 +21,8 @@ const branch = (test, left, right = identity) => BaseComponent =>
         this.factory = this.leftFactory
       } else {
         this.rightFactory =
-          this.rightFactory || createEagerFactory(right(BaseComponent))
+          this.rightFactory ||
+          createEagerFactory((right || identity)(BaseComponent))
         this.factory = this.rightFactory
       }
     }


### PR DESCRIPTION
To run

``` bash
npm run jest-test
# OR
npm run jest-test -- --watch
```

I've just played with jest and the first test have found a bug, 
`console.error` in createHelper which was not found with ava ;-)
So +1 to jest.

What are you thinking (everyone who read this) about jest snapshot testing. 

IMO 
`-` tests sources are now less readable - or even unredable. 
`+` BTW test sources with snapshot together is readable for me.
`+` test result output with snapshot diff are more readable for me.

Example:
![image](https://cloud.githubusercontent.com/assets/5077042/18730409/e05525f6-805e-11e6-82df-bff2c5062819.png)
