### PR TITLE
Remove function and arguments length check in createHelper

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postinstall": "babel-node scripts/installNestedPackageDeps.js"
   },
   "devDependencies": {
-    "ava": "^0.15.2",
+    "ava": "^0.16.0",
     "babel-cli": "^6.5.1",
     "babel-core": "^6.5.2",
     "babel-eslint": "^6.0.4",

--- a/src/packages/recompose/__tests__/branch-test.js
+++ b/src/packages/recompose/__tests__/branch-test.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon'
 import test from 'ava'
 import React from 'react'
 import { branch, compose, withState, withProps } from '../'
@@ -48,4 +49,23 @@ test('branch defaults third argument to identity function', t => {
   const right = wrapper.find('.right').text()
 
   t.is(right, 'Right')
+})
+
+test('branch third argument should not cause console error', t => {
+  const error = sinon.stub(console, 'error')
+  const Component = () => <div className="right">Component</div>
+
+  const BranchedComponent = branch(
+    () => false,
+    v => v,
+    v => v
+  )(Component)
+
+  mount(<BranchedComponent />)
+
+  t.is(error.called, false)
+
+  /* eslint-disable */
+  error.restore()
+  /* eslint-enable */
 })

--- a/src/packages/recompose/__tests__/createHelper-test.js
+++ b/src/packages/recompose/__tests__/createHelper-test.js
@@ -1,6 +1,5 @@
 import test from 'ava'
 import createHelper from '../createHelper'
-import sinon from 'sinon'
 
 test('createHelper properly sets display name', t => {
   const BaseComponent = { displayName: 'Base' }
@@ -30,23 +29,4 @@ test('createHelper works for zero-arg helpers', t => {
     createHelper(func, 'func', false, true)(BaseComponent).displayName,
     undefined
   )
-})
-
-test.serial('createHelper warns if too many arguments are passed to a helper', t => {
-  const error = sinon.stub(console, 'error')
-  const func = (a, b, c) => ({ a, b, c })
-  const helper = createHelper(func, 'func')
-  helper(1, 2, 3)
-  t.false(error.called)
-
-  helper(1, 2, 3, 4)
-  t.is(
-    error.firstCall.args[0],
-    'Too many arguments passed to func(). It should called like so: ' +
-    'func(...args)(BaseComponent).'
-  )
-
-  /* eslint-disable */
-  console.error.restore()
-  /* eslint-enable */
 })

--- a/src/packages/recompose/branch.js
+++ b/src/packages/recompose/branch.js
@@ -4,7 +4,7 @@ import createEagerFactory from './createEagerFactory'
 
 const identity = component => component
 
-const branch = (test, left, right) => BaseComponent =>
+const branch = (test, left, right = identity) => BaseComponent =>
   class extends React.Component {
     LeftComponent = null;
     RightComponent = null;
@@ -21,8 +21,7 @@ const branch = (test, left, right) => BaseComponent =>
         this.factory = this.leftFactory
       } else {
         this.rightFactory =
-          this.rightFactory ||
-            createEagerFactory((right || identity)(BaseComponent))
+          this.rightFactory || createEagerFactory(right(BaseComponent))
         this.factory = this.rightFactory
       }
     }

--- a/src/packages/recompose/branch.js
+++ b/src/packages/recompose/branch.js
@@ -4,7 +4,7 @@ import createEagerFactory from './createEagerFactory'
 
 const identity = component => component
 
-const branch = (test, left, right = identity) => BaseComponent =>
+const branch = (test, left, right) => BaseComponent =>
   class extends React.Component {
     LeftComponent = null;
     RightComponent = null;
@@ -21,7 +21,8 @@ const branch = (test, left, right = identity) => BaseComponent =>
         this.factory = this.leftFactory
       } else {
         this.rightFactory =
-          this.rightFactory || createEagerFactory(right(BaseComponent))
+          this.rightFactory ||
+            createEagerFactory((right || identity)(BaseComponent))
         this.factory = this.rightFactory
       }
     }

--- a/src/packages/recompose/createHelper.js
+++ b/src/packages/recompose/createHelper.js
@@ -17,22 +17,12 @@ const createHelper = (
       }
     }
 
-    return (...args) => {
-      if (args.length > func.length) {
-        /* eslint-disable */
-        console.error(
-        /* eslint-enable */
-          `Too many arguments passed to ${helperName}(). It should called ` +
-          `like so: ${helperName}(...args)(BaseComponent).`
-        )
-      }
-
-      return BaseComponent => {
+    return (...args) =>
+      BaseComponent => {
         const Component = func(...args)(BaseComponent)
         Component.displayName = wrapDisplayName(BaseComponent, helperName)
         return Component
       }
-    }
   }
 
   return func


### PR DESCRIPTION
Failing example
branch caused a console.error at createHelper as functions with default arguments returns incorrect length of arguments.
So [this](https://github.com/acdlite/recompose/blob/master/src/packages/recompose/createHelper.js#L21) was true for branch when all arguments were provided