### PR TITLE
Make branch return a stateless functional component

### DIFF
--- a/src/packages/recompose/branch.js
+++ b/src/packages/recompose/branch.js
@@ -1,35 +1,19 @@
-import React from 'react'
 import createHelper from './createHelper'
 import createEagerFactory from './createEagerFactory'
 
-const identity = component => component
+const identity = Component => Component
 
-const branch = (test, left, right = identity) => BaseComponent =>
-  class extends React.Component {
-    constructor(props, context) {
-      super(props, context)
-      this.computeChildComponent(this.props)
+const branch = (test, left, right = identity) => BaseComponent => {
+  let leftFactory
+  let rightFactory
+  return props => {
+    if (test(props)) {
+      leftFactory = leftFactory || createEagerFactory(left(BaseComponent))
+      return leftFactory(props)
     }
-
-    computeChildComponent(props) {
-      if (test(props)) {
-        this.leftFactory =
-          this.leftFactory || createEagerFactory(left(BaseComponent))
-        this.factory = this.leftFactory
-      } else {
-        this.rightFactory =
-          this.rightFactory || createEagerFactory(right(BaseComponent))
-        this.factory = this.rightFactory
-      }
-    }
-
-    componentWillReceiveProps(nextProps) {
-      this.computeChildComponent(nextProps)
-    }
-
-    render() {
-      return this.factory(this.props)
-    }
+    rightFactory = rightFactory || createEagerFactory(right(BaseComponent))
+    return rightFactory(props)
   }
+}
 
 export default createHelper(branch, 'branch')


### PR DESCRIPTION
Not sure you would want to merge this but at least, I will learn something out of the discussion!

Currently, `branch` returns a full-fledged React component. I am wondering wether it could return a stateless functional component instead (which is interesting because the component could be eagerly rendered).

That would essentially mean that we would be fine with factories being (lazily) initialized in `render` instead of the component's constructor and the `willComponentReceiveProps` hook—is it the case?