### PR TITLE
Update isReferentiallyTransparentFunctionComponent.js

### DIFF
--- a/src/packages/recompose/isReferentiallyTransparentFunctionComponent.js
+++ b/src/packages/recompose/isReferentiallyTransparentFunctionComponent.js
@@ -5,7 +5,7 @@ const isReferentiallyTransparentFunctionComponent = Component => Boolean(
   !isClassComponent(Component) &&
   !Component.defaultProps &&
   !Component.contextTypes &&
-  !Component.propTypes
+  (process.env.NODE_ENV === 'production' || !Component.propTypes)
 )
 
 export default isReferentiallyTransparentFunctionComponent


### PR DESCRIPTION
I'm wondering about the purpose of `!Component.propTypes`.
Using `propTypes` is quite a popular pattern.
If it's only here in order to get proper warning in dev mode, that shouldn't prevent us from
instantiation less react components in production.

Hopefully, we can use [babel-plugin-transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) to increase the number of referentially transparent components