### PR TITLE
Add link to the createClass spec in the lifecycle docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -451,7 +451,7 @@ lifecycle(
 ): HigherOrderComponent
 ```
 
-A higher-order component version of [`React.createClass()`](https://facebook.github.io/react/docs/react-api.html#createclass). It supports the entire `createClass()` API, except the `render()` method, which is implemented by default (and overridden if specified; an error will be logged to the console). You should use this helper as an escape hatch, in case you need to access component lifecycle methods.
+A higher-order component version of [`React.createClass()`](https://facebook.github.io/react/docs/react-api.html#createclass). It supports the entire [`createClass()` API](https://github.com/facebook/react/blob/15-stable/src/isomorphic/classic/class/ReactClass.js#L79), except the `render()` method, which is implemented by default (and overridden if specified; an error will be logged to the console). You should use this helper as an escape hatch, in case you need to access component lifecycle methods.
 
 ### `toClass()`
 


### PR DESCRIPTION
It's surprisingly difficult to glean the exact specification of createClass from the React docs. This presents some difficulties with figuring out what exactly one can do with the `lifecycle` function.

Perhaps we can at least add a link to the actual spec in the React code?  This is admittedly a bit fragile, but I can't think of a better solution off the top of my head.