### PR TITLE
Make renderNothing as a classComponent

### DIFF
--- a/src/packages/recompose/__tests__/renderNothing-test.js
+++ b/src/packages/recompose/__tests__/renderNothing-test.js
@@ -1,8 +1,11 @@
 import test from 'ava'
+import React from 'react'
 import { renderNothing } from '../'
+import { shallow } from 'enzyme'
 
 test('renderNothing returns a component that renders null', t => {
-  const nothing = renderNothing('div')
-  t.is(nothing(), null)
-  t.is(nothing.displayName, 'Nothing')
+  const Nothing = renderNothing('div')
+  const wrapper = shallow(<Nothing />)
+  t.is(wrapper.type(), null)
+  t.is(Nothing.displayName, 'Nothing')
 })

--- a/src/packages/recompose/renderNothing.js
+++ b/src/packages/recompose/renderNothing.js
@@ -1,9 +1,14 @@
+import { Component } from 'react'
 import createHelper from './createHelper'
 
-const renderNothing = _ => {
-  const Nothing = () => null
-  Nothing.displayName = 'Nothing'
-  return Nothing
+class Nothing extends Component {
+  render() {
+    return null
+  }
 }
+
+Nothing.displayName = 'Nothing'
+
+const renderNothing = _ => Nothing
 
 export default createHelper(renderNothing, 'renderNothing', false, true)


### PR DESCRIPTION
Fixes #288 

The problem that `renderNothing` mostly used with `branch` component, 
and since in release 0.21.0 branch does not create a class, 
we have that functional component returns null, what is prohibited with React 0.14.x and only possible with https://github.com/facebook/react/releases/tag/v15.0.0

Also as renderNothing is always a `terminator` so it should not cause perf issues.


PS: not possible to write test, I have no knowledge how to have few react versions simultaneously 