### PR TITLE
Update symbol-observable to 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "gzip-size-cli": "^1.0.0",
     "jsdom": "^8.4.0",
     "kefir": "^3.2.3",
-    "most": "^0.19.7",
+    "most": "^1.0.2",
     "nyc": "^6.4.0",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",

--- a/src/packages/recompose/mostObservableConfig.js
+++ b/src/packages/recompose/mostObservableConfig.js
@@ -1,7 +1,7 @@
-import most from 'most'
+import { from, Stream } from 'most'
 
 const config = {
-  fromESObservable: most.from
+  fromESObservable: from || Stream.from
 }
 
 export default config

--- a/src/packages/recompose/package.json
+++ b/src/packages/recompose/package.json
@@ -13,7 +13,7 @@
     "change-emitter": "^0.1.2",
     "fbjs": "^0.8.1",
     "hoist-non-react-statics": "^1.0.0",
-    "symbol-observable": "^0.2.4"
+    "symbol-observable": "^1.0.4"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0"


### PR DESCRIPTION
Version 1.0 of symbol-observable is only breaking if it would be used with `require('symbol-observable')`, as recompose already uses es6 it can be upgraded without running into this breaking change as babel is already taking care about the default export.

All other changes should not affect recompose.

Here is the changelog:
 https://github.com/blesh/symbol-observable/blob/master/CHANGELOG.md

IT would be nice to do this, as currently having redux and recompose in a project, results in two versions of `symbol-observable` being bundled.

Fixes #246