### PR TITLE
Added in non-function filtering and test case

### DIFF
--- a/src/packages/recompose/__tests__/compose-test.js
+++ b/src/packages/recompose/__tests__/compose-test.js
@@ -18,6 +18,7 @@ test('compose can be seeded with multiple arguments', t => {
 test('compose returns the identity function if given no arguments', t => {
   t.is(compose()(1, 2), 1)
   t.is(compose()(3), 3)
+  t.is(compose(false,4,'test')(3), 3)
   t.is(compose()(), undefined)
 })
 

--- a/src/packages/recompose/__tests__/compose-test.js
+++ b/src/packages/recompose/__tests__/compose-test.js
@@ -18,7 +18,7 @@ test('compose can be seeded with multiple arguments', t => {
 test('compose returns the identity function if given no arguments', t => {
   t.is(compose()(1, 2), 1)
   t.is(compose()(3), 3)
-  t.is(compose(false,4,'test')(3), 3)
+  t.is(compose(false, 4, 'test')(3), 3)
   t.is(compose()(), undefined)
 })
 

--- a/src/packages/recompose/compose.js
+++ b/src/packages/recompose/compose.js
@@ -1,4 +1,6 @@
 export default function compose(...funcs) {
+  funcs = funcs.filter(func => typeof func === 'function')
+
   if (funcs.length === 0) {
     return arg => arg
   }

--- a/src/packages/recompose/compose.js
+++ b/src/packages/recompose/compose.js
@@ -1,5 +1,5 @@
-export default function compose(...funcs) {
-  funcs = funcs.filter(func => typeof func === 'function')
+export default function compose(...unfilteredFuncs) {
+  const funcs = unfilteredFuncs.filter(func => typeof func === 'function')
 
   if (funcs.length === 0) {
     return arg => arg


### PR DESCRIPTION
current implementation breaks if >1 arguments are given, but none are functions. There is already a test case for one argument, this just enhances that