### PR TITLE
Allow handlers property of withHandlers to be a factory functions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -130,11 +130,14 @@ Instead of an array of prop keys, the first parameter can also be a function tha
 withHandlers(
   handlerCreators: {
     [handlerName: string]: (props: Object) => Function
+  } |
+  handlerCreatorsFactory: (initialProps) => {
+    [handlerName: string]: (props: Object) => Function
   }
 ): HigherOrderComponent
 ```
 
-Takes an object map of handler creators. These are higher-order functions that accept a set of props and return a function handler:
+Takes an object map of handler creators or a factory function. These are higher-order functions that accept a set of props and return a function handler:
 
 This allows the handler to access the current props via closure, without needing to change its signature.
 

--- a/src/packages/recompose/withHandlers.js
+++ b/src/packages/recompose/withHandlers.js
@@ -22,7 +22,7 @@ const withHandlers = handlers => BaseComponent => {
     cachedHandlers = {};
 
     handlers = mapValues(
-      handlers,
+      typeof handlers === 'function' ? handlers(this.props) : handlers,
       (createHandler, handlerName) => (...args) => {
         const cachedHandler = this.cachedHandlers[handlerName]
         if (cachedHandler) {
@@ -36,7 +36,7 @@ const withHandlers = handlers => BaseComponent => {
           process.env.NODE_ENV !== 'production' &&
           typeof handler !== 'function'
         ) {
-          console.error(
+          console.error( // eslint-disable-line no-console
             'withHandlers(): Expected a map of higher-order functions. ' +
             'Refer to the docs for more info.'
           )


### PR DESCRIPTION
Partially the same reason as `mapStateToProps` in react-redux  allows return a factory. 

To have ability to use local selectors see [reselect](https://github.com/reactjs/reselect) (memoization, cache) 

Like 

```javascript
withHandlers((/* initialProps */) => {
  const selector_ = createSelector(({ x }) => x, x => someCalculus(x));
  return {
    getMemoizedResult: () => selector_,
  };
})
```

This is somehow similar to `withPropsOnChange` but here you can use memoized data on demand.

The other case is to hold internal state which must not cause `setState` calls, like references, for which currently people try to use different hacks with recompose. (In my case `scrollTop` from scroll events) 

```javascript
withHandlers((/* initialProps */) => {
  let ref_;
  // let handle_;
  return {
    registerChild: () => (ref) => {
       ref_ = ref;
       // if(ref_ === null) clearTimeout(handle_);
    },
    onResize: () => () => {
      ref_.updateLayout();
      // handle_ = setTimeout(ref_.updateLayout, 0); // bad hack to not use didUpdate
    }
  };
})
```

@wuct, others your thoughts?
