### PR TITLE
Remove all Unknown prop warning from tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postinstall": "babel-node scripts/installNestedPackageDeps.js"
   },
   "devDependencies": {
-    "ava": "^0.16.0",
+    "ava": "^0.17.0",
     "babel-cli": "^6.5.1",
     "babel-core": "^6.5.2",
     "babel-eslint": "^6.0.4",

--- a/src/packages/recompose/__tests__/createElement-test.js
+++ b/src/packages/recompose/__tests__/createElement-test.js
@@ -6,13 +6,13 @@ import { shallow } from 'enzyme'
 test('createEagerElement treats class components normally', t => {
   class InnerDiv extends Component {
     render() {
-      return <div bar="baz" />
+      return <div data-bar="baz" />
     }
   }
 
   class OuterDiv extends Component {
     render() {
-      return createEagerElement('div', { foo: 'bar' },
+      return createEagerElement('div', { 'data-foo': 'bar' },
         createEagerElement(InnerDiv)
       )
     }
@@ -21,16 +21,16 @@ test('createEagerElement treats class components normally', t => {
   const wrapper = shallow(<OuterDiv />)
 
   t.true(wrapper.equals(
-    <div foo="bar">
+    <div data-foo="bar">
       <InnerDiv />
     </div>
   ))
 })
 
 test('createEagerElement calls stateless function components instead of creating an intermediate React element', t => {
-  const InnerDiv = () => <div bar="baz" />
+  const InnerDiv = () => <div data-bar="baz" />
   const OuterDiv = () =>
-    createEagerElement('div', { foo: 'bar' },
+    createEagerElement('div', { 'data-foo': 'bar' },
       createEagerElement(InnerDiv)
     )
 
@@ -40,36 +40,39 @@ test('createEagerElement calls stateless function components instead of creating
   // they're the same, but because we're using stateless function components
   // here, createEagerElement() can take advantage of referential transparency
   t.true(wrapper.equals(
-    <div foo="bar">
-      <div bar="baz" />
+    <div data-foo="bar">
+      <div data-bar="baz" />
     </div>
   ))
 })
 
 test('createEagerElement handles keyed elements correctly', t => {
-  const InnerDiv = () => <div bar="baz" />
-  const Div = () => createEagerElement(InnerDiv, { foo: 'bar', key: 'key' })
+  const InnerDiv = () => <div data-bar="baz" />
+  const Div = () => createEagerElement(
+    InnerDiv,
+    { 'data-foo': 'bar', key: 'key' }
+  )
 
   const wrapper = shallow(<Div />)
 
   t.true(wrapper.equals(
-    <InnerDiv foo="bar" key="key" />
+    <InnerDiv data-foo="bar" key="key" />
   ))
 })
 
 test('createEagerElement passes children correctly', t => {
   const Div = props => <div {...props} />
-  const InnerDiv = () => <div bar="baz" />
+  const InnerDiv = () => <div data-bar="baz" />
   const OuterDiv = () =>
-    createEagerElement(Div, { foo: 'bar' },
+    createEagerElement(Div, { 'data-foo': 'bar' },
       createEagerElement(InnerDiv)
     )
 
   const wrapper = shallow(<OuterDiv />)
 
   t.true(wrapper.equals(
-    <div foo="bar">
-      <div bar="baz" />
+    <div data-foo="bar">
+      <div data-bar="baz" />
     </div>
   ))
 })

--- a/src/packages/recompose/__tests__/defaultProps-test.js
+++ b/src/packages/recompose/__tests__/defaultProps-test.js
@@ -4,25 +4,25 @@ import { defaultProps } from '../'
 import { shallow } from 'enzyme'
 
 test('defaultProps passes additional props to base component', t => {
-  const DoReMi = defaultProps({ so: 'do', la: 'fa' })('div')
+  const DoReMi = defaultProps({ 'data-so': 'do', 'data-la': 'fa' })('div')
   t.is(DoReMi.displayName, 'defaultProps(div)')
 
   const div = shallow(<DoReMi />).find('div')
-  t.true(div.equals(<div so="do" la="fa" />))
+  t.true(div.equals(<div data-so="do" data-la="fa" />))
 })
 
 test('defaultProps has lower precendence than props from owner', t => {
-  const DoReMi = defaultProps({ so: 'do', la: 'fa' })('div')
+  const DoReMi = defaultProps({ 'data-so': 'do', 'data-la': 'fa' })('div')
   t.is(DoReMi.displayName, 'defaultProps(div)')
 
-  const div = shallow(<DoReMi la="ti" />).find('div')
-  t.true(div.equals(<div so="do" la="ti" />))
+  const div = shallow(<DoReMi data-la="ti" />).find('div')
+  t.true(div.equals(<div data-so="do" data-la="ti" />))
 })
 
 test('defaultProps overrides undefined owner props', t => {
-  const DoReMi = defaultProps({ so: 'do', la: 'fa' })('div')
+  const DoReMi = defaultProps({ 'data-so': 'do', 'data-la': 'fa' })('div')
   t.is(DoReMi.displayName, 'defaultProps(div)')
 
-  const div = shallow(<DoReMi la={undefined} />).find('div')
-  t.true(div.equals(<div so="do" la="fa" />))
+  const div = shallow(<DoReMi data-la={undefined} />).find('div')
+  t.true(div.equals(<div data-so="do" data-la="fa" />))
 })

--- a/src/packages/recompose/__tests__/flattenProp-test.js
+++ b/src/packages/recompose/__tests__/flattenProp-test.js
@@ -4,22 +4,26 @@ import { flattenProp } from '../'
 import { shallow } from 'enzyme'
 
 test('flattenProps flattens an object prop and spreads it into the top-level props object', t => {
-  const Counter = flattenProp('state')('div')
+  const Counter = flattenProp('data-state')('div')
   t.is(Counter.displayName, 'flattenProp(div)')
 
   const wrapper = shallow(
-    <Counter pass="through" state={{ counter: 1 }} />
+    <Counter data-pass="through" data-state={{ 'data-counter': 1 }} />
   )
 
   t.true(wrapper.equals(
-    <div pass="through" state={{ counter: 1 }} counter={1} />
+    <div
+      data-pass="through"
+      data-state={{ 'data-counter': 1 }}
+      data-counter={1}
+    />
   ))
 
   wrapper.setProps({
-    pass: 'through',
-    state: { state: 1 }
+    'data-pass': 'through',
+    'data-state': { 'data-state': 1 }
   })
   t.true(wrapper.equals(
-    <div pass="through" state={1} />
+    <div data-pass="through" data-state={1} />
   ))
 })

--- a/src/packages/recompose/__tests__/hoistStatics-test.js
+++ b/src/packages/recompose/__tests__/hoistStatics-test.js
@@ -2,9 +2,10 @@ import test from 'ava'
 import React from 'react'
 import { hoistStatics, mapProps } from '../'
 import { shallow } from 'enzyme'
+import sinon from 'sinon'
 
 test('copies non-React static properties from base component to new component', t => {
-  const BaseComponent = props => <div {...props} />
+  const BaseComponent = sinon.spy(() => null)
   BaseComponent.foo = () => {}
 
   const EnhancedComponent = hoistStatics(
@@ -13,6 +14,6 @@ test('copies non-React static properties from base component to new component', 
 
   t.is(EnhancedComponent.foo, BaseComponent.foo)
 
-  const wrapper = shallow(<EnhancedComponent n={3} />)
-  t.is(wrapper.prop('n'), 15)
+  shallow(<EnhancedComponent n={3} />)
+  t.is(BaseComponent.firstCall.args[0].n, 15)
 })

--- a/src/packages/recompose/__tests__/lifecycle-test.js
+++ b/src/packages/recompose/__tests__/lifecycle-test.js
@@ -6,13 +6,13 @@ import { lifecycle } from '../'
 test('lifecycle is a higher-order component version of React.createClass', t => {
   const enhance = lifecycle({
     componentWillMount() {
-      this.setState({ bar: 'baz' })
+      this.setState({ 'data-bar': 'baz' })
     }
   })
   const Div = enhance('div')
   t.is(Div.displayName, 'lifecycle(div)')
 
-  const div = mount(<Div foo="bar" />).find('div')
-  t.is(div.prop('foo'), 'bar')
-  t.is(div.prop('bar'), 'baz')
+  const div = mount(<Div data-foo="bar" />).find('div')
+  t.is(div.prop('data-foo'), 'bar')
+  t.is(div.prop('data-bar'), 'baz')
 })

--- a/src/packages/recompose/__tests__/mapProps-test.js
+++ b/src/packages/recompose/__tests__/mapProps-test.js
@@ -2,23 +2,26 @@ import test from 'ava'
 import React from 'react'
 import { mapProps, withState, compose } from '../'
 import { mount } from 'enzyme'
+import sinon from 'sinon'
 
 test('mapProps maps owner props to child props', t => {
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
   const StringConcat = compose(
     withState('strings', 'updateStrings', ['do', 're', 'mi']),
     mapProps(({ strings, ...rest }) => ({
       ...rest,
       string: strings.join('')
     }))
-  )('div')
+  )(component)
 
-  t.is(StringConcat.displayName, 'withState(mapProps(div))')
+  t.is(StringConcat.displayName, 'withState(mapProps(component))')
 
-  const div = mount(<StringConcat />).find('div')
-  const { updateStrings } = div.props()
-
-  t.is(div.prop('string'), 'doremi')
-
+  mount(<StringConcat />)
+  const { updateStrings } = component.firstCall.args[0]
   updateStrings(strings => [...strings, 'fa'])
-  t.is(div.prop('string'), 'doremifa')
+
+  t.is(component.firstCall.args[0].string, 'doremi')
+  t.is(component.secondCall.args[0].string, 'doremifa')
 })

--- a/src/packages/recompose/__tests__/onlyUpdateForKeys-test.js
+++ b/src/packages/recompose/__tests__/onlyUpdateForKeys-test.js
@@ -2,28 +2,35 @@ import test from 'ava'
 import React from 'react'
 import { onlyUpdateForKeys, compose, withState } from '../'
 import { mount } from 'enzyme'
+import sinon from 'sinon'
 
 test('onlyUpdateForKeys implements shouldComponentUpdate()', t => {
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
   const Counter = compose(
     withState('counter', 'updateCounter', 0),
     withState('foobar', 'updateFoobar', 'foobar'),
     onlyUpdateForKeys(['counter'])
-  )('div')
+  )(component)
 
-  t.is(Counter.displayName, 'withState(withState(onlyUpdateForKeys(div)))')
+  t.is(
+    Counter.displayName,
+    'withState(withState(onlyUpdateForKeys(component)))'
+  )
 
-  const div = mount(<Counter />).find('div')
-  const { updateCounter, updateFoobar } = div.props()
+  mount(<Counter />)
+  const { updateCounter, updateFoobar } = component.firstCall.args[0]
 
-  t.is(div.prop('counter'), 0)
-  t.is(div.prop('foobar'), 'foobar')
+  t.is(component.lastCall.args[0].counter, 0)
+  t.is(component.lastCall.args[0].foobar, 'foobar')
 
   // Does not update
   updateFoobar('barbaz')
-  t.is(div.prop('counter'), 0)
-  t.is(div.prop('foobar'), 'foobar')
+  t.true(component.calledOnce)
 
   updateCounter(42)
-  t.is(div.prop('counter'), 42)
-  t.is(div.prop('foobar'), 'barbaz')
+  t.true(component.calledTwice)
+  t.is(component.lastCall.args[0].counter, 42)
+  t.is(component.lastCall.args[0].foobar, 'barbaz')
 })

--- a/src/packages/recompose/__tests__/renameProp-test.js
+++ b/src/packages/recompose/__tests__/renameProp-test.js
@@ -5,12 +5,12 @@ import { shallow } from 'enzyme'
 
 test('renameProp renames a single prop', t => {
   const StringConcat = compose(
-    withProps({ so: 123, la: 456 }),
-    renameProp('so', 'do')
+    withProps({ 'data-so': 123, 'data-la': 456 }),
+    renameProp('data-so', 'data-do')
   )('div')
 
   t.is(StringConcat.displayName, 'withProps(renameProp(div))')
 
   const div = shallow(<StringConcat />).find('div')
-  t.deepEqual(div.props(), { do: 123, la: 456 })
+  t.deepEqual(div.props(), { 'data-do': 123, 'data-la': 456 })
 })

--- a/src/packages/recompose/__tests__/renameProps-test.js
+++ b/src/packages/recompose/__tests__/renameProps-test.js
@@ -5,14 +5,14 @@ import { shallow } from 'enzyme'
 
 test('renameProps renames props', t => {
   const StringConcat = compose(
-    withProps({ so: 123, la: 456 }),
-    renameProps({ so: 'do', la: 'fa' })
+    withProps({ 'data-so': 123, 'data-la': 456 }),
+    renameProps({ 'data-so': 'data-do', 'data-la': 'data-fa' })
   )('div')
 
   t.is(StringConcat.displayName, 'withProps(renameProps(div))')
 
   const div = shallow(<StringConcat />).find('div')
 
-  t.is(div.prop('do'), 123)
-  t.is(div.prop('fa'), 456)
+  t.is(div.prop('data-do'), 123)
+  t.is(div.prop('data-fa'), 456)
 })

--- a/src/packages/recompose/__tests__/renderComponent-test.js
+++ b/src/packages/recompose/__tests__/renderComponent-test.js
@@ -2,24 +2,28 @@ import test from 'ava'
 import React from 'react'
 import { renderComponent, withState, compose, branch } from '../'
 import { mount } from 'enzyme'
+import sinon from 'sinon'
 
 test('renderComponent always renders the given component', t => {
+  const componentA = sinon.spy(() => null)
+  const componentB = sinon.spy(() => null)
+
   const Foobar = compose(
     withState('flip', 'updateFlip', false),
     branch(
       props => props.flip,
-      renderComponent('div'),
-      renderComponent('span')
+      renderComponent(componentA),
+      renderComponent(componentB)
     )
   )(null)
 
-  const wrapper = mount(<Foobar />)
-  const { updateFlip } = wrapper.find('span').props()
+  mount(<Foobar />)
+  const { updateFlip } = componentB.firstCall.args[0]
 
-  t.is(wrapper.find('span').length, 1)
-  t.is(wrapper.find('div').length, 0)
+  t.true(componentB.calledOnce)
+  t.true(componentA.notCalled)
 
   updateFlip(true)
-  t.is(wrapper.find('span').length, 0)
-  t.is(wrapper.find('div').length, 1)
+  t.true(componentB.calledOnce)
+  t.true(componentA.calledOnce)
 })

--- a/src/packages/recompose/__tests__/shouldUpdate-test.js
+++ b/src/packages/recompose/__tests__/shouldUpdate-test.js
@@ -3,29 +3,33 @@ import React from 'react'
 import { shouldUpdate, compose, withState } from '../'
 import { countRenders } from './utils'
 import { mount } from 'enzyme'
+import sinon from 'sinon'
 
 test('shouldUpdate implements shouldComponentUpdate', t => {
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
   const initialTodos = ['eat', 'drink', 'sleep']
   const Todos = compose(
     withState('todos', 'updateTodos', initialTodos),
     shouldUpdate((props, nextProps) => props.todos !== nextProps.todos),
     countRenders
-  )('div')
+  )(component)
 
-  t.is(Todos.displayName, 'withState(shouldUpdate(countRenders(div)))')
+  t.is(Todos.displayName, 'withState(shouldUpdate(countRenders(component)))')
 
-  const div = mount(<Todos />).find('div')
-  const { updateTodos } = div.props()
+  mount(<Todos />)
+  const { updateTodos } = component.firstCall.args[0]
 
-  t.is(div.prop('todos'), initialTodos)
-  t.is(div.prop('renderCount'), 1)
+  t.is(component.lastCall.args[0].todos, initialTodos)
+  t.is(component.lastCall.args[0].renderCount, 1)
 
   // Does not re-render
   updateTodos(initialTodos)
-  t.is(div.prop('todos'), initialTodos)
-  t.is(div.prop('renderCount'), 1)
+  t.true(component.calledOnce)
 
   updateTodos(todos => todos.slice(0, -1))
-  t.deepEqual(div.prop('todos'), ['eat', 'drink'])
-  t.is(div.prop('renderCount'), 2)
+  t.true(component.calledTwice)
+  t.deepEqual(component.lastCall.args[0].todos, ['eat', 'drink'])
+  t.is(component.lastCall.args[0].renderCount, 2)
 })

--- a/src/packages/recompose/__tests__/toClass-test.js
+++ b/src/packages/recompose/__tests__/toClass-test.js
@@ -2,6 +2,7 @@ import test from 'ava'
 import React, { PropTypes } from 'react'
 import { toClass, withContext, compose } from '../'
 import { mount } from 'enzyme'
+import sinon from 'sinon'
 
 test('toClass returns the base component if it is already a class', t => {
   class BaseComponent extends React.Component {
@@ -15,8 +16,8 @@ test('toClass returns the base component if it is already a class', t => {
 })
 
 test('toClass copies propTypes, displayName, contextTypes and defaultProps from base component', t => {
-  const StatelessComponent = props =>
-    <div {...props} />
+  const StatelessComponent = () =>
+    <div />
 
   StatelessComponent.displayName = 'Stateless'
   StatelessComponent.propTypes = { foo: PropTypes.string }
@@ -32,8 +33,7 @@ test('toClass copies propTypes, displayName, contextTypes and defaultProps from 
 })
 
 test('toClass passes defaultProps correctly', t => {
-  const StatelessComponent = props =>
-    <div {...props} />
+  const StatelessComponent = sinon.spy(() => null)
 
   StatelessComponent.displayName = 'Stateless'
   StatelessComponent.propTypes = { foo: PropTypes.string }
@@ -42,9 +42,9 @@ test('toClass passes defaultProps correctly', t => {
 
   const TestComponent = toClass(StatelessComponent)
 
-  const div = mount(<TestComponent />).find('div')
-  t.is(div.prop('foo'), 'bar')
-  t.is(div.prop('fizz'), 'buzz')
+  mount(<TestComponent />)
+  t.is(StatelessComponent.lastCall.args[0].foo, 'bar')
+  t.is(StatelessComponent.lastCall.args[0].fizz, 'buzz')
 })
 
 test('toClass passes context and props correctly', t => {
@@ -69,7 +69,7 @@ test('toClass passes context and props correctly', t => {
 
 
   const StatelessComponent = (props, context) =>
-    <div props={props} context={context} />
+    <div data-props={props} data-context={context} />
 
   StatelessComponent.contextTypes = { store: PropTypes.object }
 
@@ -81,8 +81,8 @@ test('toClass passes context and props correctly', t => {
     </Provider>
   ).find('div')
 
-  t.is(div.prop('props').fizz, 'fizzbuzz')
-  t.is(div.prop('context').store, store)
+  t.is(div.prop('data-props').fizz, 'fizzbuzz')
+  t.is(div.prop('data-context').store, store)
 })
 
 test('toClass works with strings (DOM components)', t => {

--- a/src/packages/recompose/__tests__/withContext-test.js
+++ b/src/packages/recompose/__tests__/withContext-test.js
@@ -2,6 +2,7 @@ import test from 'ava'
 import React, { Component, PropTypes } from 'react'
 import { withContext, getContext, compose, mapProps } from '../'
 import { mount } from 'enzyme'
+import sinon from 'sinon'
 
 test('withContext + getContext adds to and grabs from context', t => {
   // Mini React Redux clone
@@ -36,15 +37,18 @@ test('withContext + getContext adds to and grabs from context', t => {
     mapProps(props => selector(props.store.getState()))
   )
 
-  const TodoList = connect(({ todos }) => ({ todos }))('div')
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
 
-  t.is(TodoList.displayName, 'getContext(mapProps(div))')
+  const TodoList = connect(({ todos }) => ({ todos }))(component)
 
-  const div = mount(
+  t.is(TodoList.displayName, 'getContext(mapProps(component))')
+
+  mount(
     <Provider store={store}>
       <TodoList />
     </Provider>
-  ).find('div')
+  )
 
-  t.deepEqual(div.prop('todos'), ['eat', 'drink', 'sleep'])
+  t.deepEqual(component.lastCall.args[0].todos, ['eat', 'drink', 'sleep'])
 })

--- a/src/packages/recompose/__tests__/withHandlers-test.js
+++ b/src/packages/recompose/__tests__/withHandlers-test.js
@@ -47,14 +47,17 @@ test('withHandlers passes immutable handlers', t => {
   const enhance = withHandlers({
     handler: () => () => null
   })
-  const Div = enhance('div')
+  const component = sinon.spy(() => null)
+  const Div = enhance(component)
 
   const wrapper = mount(<Div />)
-  const div = wrapper.find('div')
-  const handler = div.prop('handler')
-
   wrapper.setProps({ foo: 'bar' })
-  t.is(div.prop('handler'), handler)
+
+  t.true(component.calledTwice)
+  t.is(
+    component.firstCall.args[0].handler,
+    component.secondCall.args[0].handler
+  )
 })
 
 test('withHandlers caches handlers properly', t => {
@@ -69,11 +72,12 @@ test('withHandlers caches handlers properly', t => {
       }
     }
   })
-  const Div = enhance('div')
+
+  const component = sinon.spy(() => null)
+  const Div = enhance(component)
 
   const wrapper = mount(<Div foo="bar" />)
-  const div = wrapper.find('div')
-  const handler = div.prop('handler')
+  const { handler } = component.firstCall.args[0]
 
   // Don't create handler until it is called
   t.is(handlerCreationSpy.callCount, 0)

--- a/src/packages/recompose/__tests__/withProps-test.js
+++ b/src/packages/recompose/__tests__/withProps-test.js
@@ -4,27 +4,27 @@ import { withProps } from '../'
 import { shallow } from 'enzyme'
 
 test('withProps passes additional props to base component', t => {
-  const DoReMi = withProps({ so: 'do', la: 'fa' })('div')
+  const DoReMi = withProps({ 'data-so': 'do', 'data-la': 'fa' })('div')
   t.is(DoReMi.displayName, 'withProps(div)')
 
   const div = shallow(<DoReMi />).find('div')
-  t.is(div.prop('so'), 'do')
-  t.is(div.prop('la'), 'fa')
+  t.is(div.prop('data-so'), 'do')
+  t.is(div.prop('data-la'), 'fa')
 })
 
 test('withProps takes precedent over owner props', t => {
-  const DoReMi = withProps({ so: 'do', la: 'fa' })('div')
+  const DoReMi = withProps({ 'data-so': 'do', 'data-la': 'fa' })('div')
 
-  const div = shallow(<DoReMi la="ti" />).find('div')
-  t.is(div.prop('so'), 'do')
-  t.is(div.prop('la'), 'fa')
+  const div = shallow(<DoReMi data-la="ti" />).find('div')
+  t.is(div.prop('data-so'), 'do')
+  t.is(div.prop('data-la'), 'fa')
 })
 
 test('withProps should accept function', t => {
-  const DoReMi = withProps(({ la }) => ({
-    so: la
+  const DoReMi = withProps((props) => ({
+    'data-so': props['data-la']
   }))('div')
 
-  const div = shallow(<DoReMi la="la" />).find('div')
-  t.is(div.prop('so'), 'la')
+  const div = shallow(<DoReMi data-la="la" />).find('div')
+  t.is(div.prop('data-so'), 'la')
 })

--- a/src/packages/recompose/__tests__/withPropsOnChange-test.js
+++ b/src/packages/recompose/__tests__/withPropsOnChange-test.js
@@ -5,6 +5,9 @@ import { mount } from 'enzyme'
 import sinon from 'sinon'
 
 test('withPropsOnChange maps subset of owner props to child props', t => {
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
   const mapSpy = sinon.spy()
   const StringConcat = compose(
     withState('strings', 'updateStrings', { a: 'a', b: 'b', c: 'c' }),
@@ -19,27 +22,29 @@ test('withPropsOnChange maps subset of owner props to child props', t => {
         }
       }
     )
-  )('div')
+  )(component)
 
   t.is(
     StringConcat.displayName,
-    'withState(flattenProp(withPropsOnChange(div)))'
+    'withState(flattenProp(withPropsOnChange(component)))'
   )
 
-  const div = mount(<StringConcat />).find('div')
-  const { updateStrings } = div.props()
-
-  t.is(div.prop('foobar'), 'ab')
+  mount(<StringConcat />)
+  const { updateStrings } = component.firstCall.args[0]
+  t.is(component.lastCall.args[0].foobar, 'ab')
+  t.true(component.calledOnce)
   t.is(mapSpy.callCount, 1)
 
   // Does not re-map for non-dependent prop updates
   updateStrings(strings => ({ ...strings, c: 'baz' }))
-  t.is(div.prop('foobar'), 'ab')
-  t.is(div.prop('c'), 'c')
+  t.is(component.lastCall.args[0].foobar, 'ab')
+  t.is(component.lastCall.args[0].c, 'c')
+  t.true(component.calledTwice)
   t.is(mapSpy.callCount, 1)
 
   updateStrings(strings => ({ ...strings, a: 'foo', b: 'bar' }))
-  t.is(div.prop('foobar'), 'foobar')
-  t.is(div.prop('c'), 'baz')
+  t.is(component.lastCall.args[0].foobar, 'foobar')
+  t.is(component.lastCall.args[0].c, 'baz')
+  t.true(component.calledThrice)
   t.is(mapSpy.callCount, 2)
 })

--- a/src/packages/recompose/__tests__/withReducer-test.js
+++ b/src/packages/recompose/__tests__/withReducer-test.js
@@ -2,10 +2,14 @@ import test from 'ava'
 import React from 'react'
 import { withReducer, compose, flattenProp } from '../'
 import { mount } from 'enzyme'
+import sinon from 'sinon'
 
 const SET_COUNTER = 'SET_COUNTER'
 
 test('adds a stateful value and a function for updating it', t => {
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
   const initialState = { counter: 0 }
 
   const reducer = (state, action) =>
@@ -21,20 +25,23 @@ test('adds a stateful value and a function for updating it', t => {
       initialState
     ),
     flattenProp('state')
-  )('div')
+  )(component)
 
-  t.is(Counter.displayName, 'withReducer(flattenProp(div))')
+  t.is(Counter.displayName, 'withReducer(flattenProp(component))')
 
-  const div = mount(<Counter />).find('div')
-  const { dispatch } = div.props()
+  mount(<Counter />)
+  const { dispatch } = component.firstCall.args[0]
 
-  t.is(div.prop('counter'), 0)
+  t.is(component.lastCall.args[0].counter, 0)
 
   dispatch({ type: SET_COUNTER, payload: 18 })
-  t.is(div.prop('counter'), 18)
+  t.is(component.lastCall.args[0].counter, 18)
 })
 
 test('calls initialState when it is a function', t => {
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
   const initialState = ({ initialCount }) => ({ counter: initialCount })
 
   const reducer = (state, action) =>
@@ -50,14 +57,17 @@ test('calls initialState when it is a function', t => {
       initialState
     ),
     flattenProp('state')
-  )('div')
+  )(component)
 
-  const div = mount(<Counter initialCount={10} />).find('div')
+  mount(<Counter initialCount={10} />)
 
-  t.is(div.prop('counter'), 10)
+  t.is(component.lastCall.args[0].counter, 10)
 })
 
 test('receives state from reducer when initialState is not provided', t => {
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
   const initialState = { counter: 0 }
 
   const reducer = (state = initialState, action) =>
@@ -72,9 +82,9 @@ test('receives state from reducer when initialState is not provided', t => {
       reducer
     ),
     flattenProp('state')
-  )('div')
+  )(component)
 
-  const div = mount(<Counter />).find('div')
+  mount(<Counter />)
 
-  t.is(div.prop('counter'), 0)
+  t.is(component.lastCall.args[0].counter, 0)
 })

--- a/src/packages/recompose/__tests__/withState-test.js
+++ b/src/packages/recompose/__tests__/withState-test.js
@@ -5,54 +5,67 @@ import { mount } from 'enzyme'
 import sinon from 'sinon'
 
 test('withState adds a stateful value and a function for updating it', t => {
-  const Counter = withState('counter', 'updateCounter', 0)('div')
-  t.is(Counter.displayName, 'withState(div)')
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
 
-  const div = mount(<Counter pass="through" />).find('div')
-  const { updateCounter } = div.props()
+  const Counter = withState('counter', 'updateCounter', 0)(component)
+  t.is(Counter.displayName, 'withState(component)')
 
-  t.is(div.prop('counter'), 0)
-  t.is(div.prop('pass'), 'through')
+  mount(<Counter pass="through" />)
+  const { updateCounter } = component.firstCall.args[0]
+
+  t.is(component.lastCall.args[0].counter, 0)
+  t.is(component.lastCall.args[0].pass, 'through')
 
   updateCounter(n => n + 9)
   updateCounter(n => n * 2)
-  t.is(div.prop('counter'), 18)
-  t.is(div.prop('pass'), 'through')
+
+  t.is(component.lastCall.args[0].counter, 18)
+  t.is(component.lastCall.args[0].pass, 'through')
 })
 
 test('withState also accepts a non-function, which is passed directly to setState()', t => {
-  const Counter = withState('counter', 'updateCounter', 0)('div')
-  const div = mount(<Counter />).find('div')
-  const { updateCounter } = div.props()
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
+  const Counter = withState('counter', 'updateCounter', 0)(component)
+  mount(<Counter />)
+  const { updateCounter } = component.firstCall.args[0]
 
   updateCounter(18)
-  t.is(div.prop('counter'), 18)
+  t.is(component.lastCall.args[0].counter, 18)
 })
 
 test('withState accepts setState() callback', t => {
-  const Counter = withState('counter', 'updateCounter', 0)('div')
-  const div = mount(<Counter />).find('div')
-  const { updateCounter } = div.props()
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
+  const Counter = withState('counter', 'updateCounter', 0)(component)
+  mount(<Counter />)
+  const { updateCounter } = component.firstCall.args[0]
 
   const renderSpy = sinon.spy(() => {
-    t.is(div.prop('counter'), 18)
+    t.is(component.lastCall.args[0].counter, 18)
   })
 
-  t.is(div.prop('counter'), 0)
+  t.is(component.lastCall.args[0].counter, 0)
   updateCounter(18, renderSpy)
 })
 
 test('withState also accepts initialState as function of props', t => {
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
   const Counter = withState(
     'counter',
     'updateCounter',
     props => props.initialCounter
-  )('div')
+  )(component)
 
-  const div = mount(<Counter initialCounter={1} />).find('div')
-  const { updateCounter } = div.props()
+  mount(<Counter initialCounter={1} />)
+  const { updateCounter } = component.firstCall.args[0]
 
-  t.is(div.prop('counter'), 1)
+  t.is(component.lastCall.args[0].counter, 1)
   updateCounter(n => n * 3)
-  t.is(div.prop('counter'), 3)
+  t.is(component.lastCall.args[0].counter, 3)
 })


### PR DESCRIPTION
Few screens of tests warning like

```
Warning: Unknown prop `blabla` on <blublu> tag. 
Remove this prop from the element. 
For details, see https://fb.me/react-unknown-prop
```

has fixed (removed).

Ava updated.