### PR TITLE
Added recursive pick for withPropsOnChange feature

### DIFF
--- a/src/packages/recompose/__tests__/pick-test.js
+++ b/src/packages/recompose/__tests__/pick-test.js
@@ -1,0 +1,29 @@
+import test from 'ava'
+import pick from '../utils/pick'
+
+test('pick', t => {
+  t.deepEqual(
+    pick({
+      one: '1',
+      dont: 'include',
+      two: {
+        deep: {
+          value: 'true'
+        }
+      },
+      root: {},
+      three: '3'
+    }, [
+      'one',
+      ['two', 'deep', 'value'],
+      ['root', 'missed'],
+      'three'
+    ]),
+    {
+      one: '1',
+      'two\ndeep\nvalue': 'true',
+      'root\nmissed': undefined,
+      three: '3'
+    }
+  )
+})

--- a/src/packages/recompose/utils/pick.js
+++ b/src/packages/recompose/utils/pick.js
@@ -2,7 +2,18 @@ const pick = (obj, keys) => {
   const result = {}
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i]
-    if (obj.hasOwnProperty(key)) {
+    if (Array.isArray(key)) {
+      let value = obj
+      for (let x = 0; x < key.length; x++) {
+        const deepKey = key[x]
+        if (!value.hasOwnProperty(deepKey)) {
+          value = undefined
+          break
+        }
+        value = value[deepKey]
+      }
+      result[key.join('\n')] = value
+    } else if (obj.hasOwnProperty(key)) {
       result[key] = obj[key]
     }
   }


### PR DESCRIPTION
Hi

First of all I would like to thank you for this awesome library!

I often use the `withPropsOnChange` but I miss the functionality to listen for nested properties and writing functions looks totally ugly. So I came up with this.

```js
withPropsOnChange(
  (props, nextProps) =>
    props.router.routeParams.something !== nextProps.router.routeParams.something ||
    props.somethingElse !== nextProps.somethingElse ||
    props.thisStartToLookUgly !== nextProps.thisStartToLookUgly,
  ({
    fetchSomething,
    router: { routeParams: { something } },
    somethingElse,
    thisStartToLookUgly
  }) => fetchSomething(something, somethingElse, thisStartToLookUgly)
)
```

The code looks even more ugly if the `routeParams` isn't defined with current implementation. You then need to have checks if it exists that bloats the code.

With my feature request you can replace this with:

```js
withPropsOnChange(
  [
    ['router', 'routeParams', 'something'],
    'somethingElse',
    'thisStartToLookGood'
  ],
  ({
    fetchSomething,
    router: { routeParams: { something } },
    somethingElse,
    thisStartToLookGood
  }) => fetchSomething(something, somethingElse, thisStartToLookGood)
)
```