### PR TITLE
Add toESObservable identity fn to rxjsObservableConfig

### DIFF
--- a/src/packages/recompose/rxjsObservableConfig.js
+++ b/src/packages/recompose/rxjsObservableConfig.js
@@ -1,7 +1,8 @@
 import Rx from 'rxjs'
 
 const config = {
-  fromESObservable: Rx.Observable.from
+  fromESObservable: Rx.Observable.from,
+  toESObservable: stream => stream
 }
 
 export default config


### PR DESCRIPTION
This PR adds a `toESObservable` function to the `rxjsObservableConfig`, so it can be used with `componentFromStreamWithConfig`. I ran into this issue writing a library with recompose and RxJS. I don't want the library overwrite if someone has set the global config, but using `rxjsObservableConfig` with `componentFromStreamWithConfig` will throw an error, because `toESObservable` isn't defined.

It seems the tests for `componentFromStream` are skipped, so I didn't add a test for this case. Let me know if there's anything else I should add to this PR. Thanks.