### PR TITLE
Change string component creation using React.createElement in toClass function

### DIFF
--- a/src/packages/recompose/__tests__/toClass-test.js
+++ b/src/packages/recompose/__tests__/toClass-test.js
@@ -87,6 +87,6 @@ test('toClass passes context and props correctly', t => {
 
 test('toClass works with strings (DOM components)', t => {
   const Div = toClass('div')
-  const div = mount(<Div>Hello</Div>).find('div')
-  t.is(div.text(), 'Hello')
+  const div = mount(<Div>Hello</Div>)
+  t.is(div.html(), '<div>Hello</div>')
 })

--- a/src/packages/recompose/toClass.js
+++ b/src/packages/recompose/toClass.js
@@ -10,7 +10,7 @@ const toClass = baseComponent => {
   class ToClass extends Component {
     render() {
       if (typeof baseComponent === 'string') {
-        return <baseComponent {...this.props} />
+        return React.createElement(baseComponent, this.props)
       }
       return baseComponent(this.props, this.context)
     }


### PR DESCRIPTION
Using the `toClass` function to create a component using a string it create a component with the `baseComponent` variable not resolved, so if I try to create a component calling: `toClass('textarea')` I will receive as output a `<baseComponent>` element and not a `<textarea>` element.