### PR TITLE
componentFromStream can potentially throw EmptyError: no elements in sequence

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -702,6 +702,8 @@ const Counter = componentFromStream(props$ => {
 })
 ```
 
+**Note: As from 0.22.0 componentFromStream will complete the stream and usage of [first](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-first), [last](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-last) or [single](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-single) methods can potentially throw [EmptyError](http://reactivex.io/rxjs/class/es6/util/EmptyError.js~EmptyError.html).**
+
 ### `mapPropsStream()`
 
 ```js

--- a/docs/API.md
+++ b/docs/API.md
@@ -702,8 +702,6 @@ const Counter = componentFromStream(props$ => {
 })
 ```
 
-**Note: As from 0.22.0 `componentFromStream` will complete the stream during unmount and usage of [first](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-first), [last](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-last) or [single](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-single) methods can potentially throw [EmptyError](http://reactivex.io/rxjs/class/es6/util/EmptyError.js~EmptyError.html).**
-
 ### `mapPropsStream()`
 
 ```js

--- a/docs/API.md
+++ b/docs/API.md
@@ -702,7 +702,7 @@ const Counter = componentFromStream(props$ => {
 })
 ```
 
-**Note: As from 0.22.0 componentFromStream will complete the stream and usage of [first](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-first), [last](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-last) or [single](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-single) methods can potentially throw [EmptyError](http://reactivex.io/rxjs/class/es6/util/EmptyError.js~EmptyError.html).**
+**Note: As from 0.22.0 `componentFromStream` will complete the stream during unmount and usage of [first](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-first), [last](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-last) or [single](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-single) methods can potentially throw [EmptyError](http://reactivex.io/rxjs/class/es6/util/EmptyError.js~EmptyError.html).**
 
 ### `mapPropsStream()`
 

--- a/src/packages/recompose/__tests__/componentFromStream-test.js
+++ b/src/packages/recompose/__tests__/componentFromStream-test.js
@@ -94,3 +94,23 @@ test('complete props stream before unmounting', t => {
   wrapper.unmount()
   t.is(counter, 0)
 })
+
+test('completed props stream should throw an exception', t => {
+  const Div = componentFromStream(props$ => {
+    const first$ = props$
+      .filter(() => false)
+      .first()
+      .startWith(null)
+
+    return props$.combineLatest(
+      first$,
+      props1 => <div {...props1} />
+    )
+  })
+
+  const wrapper = mount(<Div />)
+
+  t.is(wrapper.find('div').length, 1)
+
+  t.throws(() => wrapper.unmount(), /no elements in sequence/)
+})


### PR DESCRIPTION
As from 0.22.0 `componentFromStream` will complete the stream during unmount and usage of [first](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-first), [last](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-last) or [single](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-single) methods can potentially throw [EmptyError](http://reactivex.io/rxjs/class/es6/util/EmptyError.js~EmptyError.html).

See #220 and #303 