### PR TITLE
add note for the use of setState in lifecycle

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -456,6 +456,8 @@ lifecycle(
 
 A higher-order component version of [`React.createClass()`](https://facebook.github.io/react/docs/react-api.html#createclass). It supports the entire `createClass()` API, except the `render()` method, which is implemented by default (and overridden if specified; an error will be logged to the console). You should use this helper as an escape hatch, in case you need to access component lifecycle methods.
 
+Any state changes made in a lifecycle method, by using `setState`, will be propagated to the wrapped component as props.
+
 ### `toClass()`
 
 ```js


### PR DESCRIPTION
Adding a note to clear things up with using state in `lifecycle`.

I was trying to implement an async data loading component and the doc doesn't say anything about how `this.state` is handled which is confusing. So I had to read the source code to determine if state changes were propagated. As suspected it does and that fact should be included in the docs.