### PR TITLE
update doc on branch on optional parameter

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -296,11 +296,11 @@ Passes two additional props to the base component: a state value, and a dispatch
 branch(
   test: (props: Object) => boolean,
   left: HigherOrderComponent,
-  right: HigherOrderComponent
+  [right: HigherOrderComponent]
 ): HigherOrderComponent
 ```
 
-Accepts a test function and two higher-order components. The test function is passed the props from the owner. If it returns true, the `left` higher-order component is applied to `BaseComponent`; otherwise, the `right` higher-order component is applied.
+Accepts a test function and two higher-order components. The test function is passed the props from the owner. If it returns true, the `left` higher-order component is applied to `BaseComponent`; otherwise, the optional `right` higher-order component is applied or the wrapped component to the returned higher-order component.
 
 ### `renderComponent()`
 


### PR DESCRIPTION
The docs for `branch` does not mention the fact the the third argument is optional or that the function is kinda curried. This is not inferred until you read the example in `renderComponent` which is contextually the not really the place you'd expect this to be documented in.

Not sure about syntax for optional parameters, so I went with the usual brackets for optional items `[ ... ]`.

Refs #287 