### PR TITLE
Pass handlers object (self) to createHandler function

### DIFF
--- a/src/packages/recompose/withHandlers.js
+++ b/src/packages/recompose/withHandlers.js
@@ -27,7 +27,7 @@ const withHandlers = handlers => BaseComponent => {
           return cachedHandler(...args)
         }
 
-        const handler = createHandler(this.props)
+        const handler = createHandler(this.props, handlers)
         this.cachedHandlers[handlerName] = handler
 
         if (


### PR DESCRIPTION
This allows creation and reference of handlers in a single `withHandlers` call rather than many.

```
withHandlers({
  a: (props, handlers) => (...args) => handlers.b(...args),
  b: () => (...args) => doStuff(...arg),
})
```

Posting this here as a spitball idea. Will wrap up with tests if we think this is a fair addition to recompose!

This avoids the following requirement.

```
withHandlers({
  b: () => (...args) => doStuff(...arg),
})
withHandlers({
  a: (props) => (...args) => props.b(...args),
})
```

Note: this has definitely popped up as a somewhat edge usage :thinking: 