### PR TITLE
Fix lifecycle to support React 15.5

### DIFF
--- a/src/packages/recompose/lifecycle.js
+++ b/src/packages/recompose/lifecycle.js
@@ -1,4 +1,4 @@
-import { createClass } from 'react'
+import { Component } from 'react'
 import createHelper from './createHelper'
 import createEagerFactory from './createEagerFactory'
 
@@ -15,17 +15,24 @@ const lifecycle = spec => BaseComponent => {
     )
   }
 
-  /* eslint-disable react/prefer-es6-class */
-  return createClass({
-    ...spec,
+  return class extends Component {
+    constructor(...args) {
+      super(...args)
+
+      Object.keys(spec).forEach(key => {
+        this[key] = typeof spec[key] === 'function'
+          ? spec[key].bind(this)
+          : spec[key]
+      })
+    }
+
     render() {
       return factory({
         ...this.props,
         ...this.state
       })
     }
-  })
-  /* eslint-enable react/prefer-es6-class */
+  }
 }
 
 export default createHelper(lifecycle, 'lifecycle')

--- a/src/packages/recompose/lifecycle.js
+++ b/src/packages/recompose/lifecycle.js
@@ -19,9 +19,7 @@ const lifecycle = spec => BaseComponent => {
     constructor(...args) {
       super(...args)
 
-      Object.keys(spec).forEach(key => {
-        this[key] = spec[key]
-      })
+      Object.assign(this, spec)
     }
 
     render() {

--- a/src/packages/recompose/lifecycle.js
+++ b/src/packages/recompose/lifecycle.js
@@ -20,9 +20,7 @@ const lifecycle = spec => BaseComponent => {
       super(...args)
 
       Object.keys(spec).forEach(key => {
-        this[key] = typeof spec[key] === 'function'
-          ? spec[key].bind(this)
-          : spec[key]
+        this[key] = spec[key]
       })
     }
 


### PR DESCRIPTION
The reason: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.createclass

Removing `createClass` at all from `lifecycle`.
(importing it from `create-react-class` will cause current package incompatibility with React 14, and all that `require` with version check is not better than current solution )

Also IMO `lifecycle` must be deprecated or even removed from recompose.

And yes possibly breaking change.