### PR TITLE
Add class-like state behavior option to withState

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -243,13 +243,14 @@ const Post = enhance(({ title, content, author }) =>
 
 ```js
 withState(
-  stateName: string,
-  stateUpdaterName: string,
+  stateName: ?string,
+  stateUpdaterName: ?string,
   initialState: any | (props: Object) => any
 ): HigherOrderComponent
 ```
+Passes two additional props to the base component: a state value, and a function to update that state value.
 
-Passes two additional props to the base component: a state value, and a function to update that state value. The state updater has the following signature:
+If stateName and stateUpdateName are provided then the behavior is as follows. The state updater has the following signature:
 
 ```js
 stateUpdater<T>((prevValue: T) => T, ?callback: Function): void
@@ -273,7 +274,20 @@ The second form accepts a single value, which is used as the new state.
 
 Both forms accept an optional second parameter, a callback function that will be executed once `setState()` is completed and the component is re-rendered.
 
-An initial state value is required. It can be either the state value itself, or a function that returns an initial state given the initial props.
+Only the initialState param is required. It can be either the state value itself, or a function that returns an initial state given the initial props.
+
+If stateName and stateUpdaterName are not provided then they default to `'state'` and `'setState'`. In this form, state and setState behave exactly like setState in a typical react class. So `state` will be an object and `setState()` will accept a new state object to merge with the existing state. In this form `setState()` also still allows either an object or function as a param for updating state:
+
+```js
+const addCounting = compose(
+  withState({ count: 0 }),
+  withHandlers({
+    increment: ({ setState }) => () => setState(({ count }) => count + 1),
+    decrement: ({ setState }) => () =>  setState(({ count }) => count - 1),
+    reset: ({ setState }) => () => setState({ count: 0 })
+  }))
+)
+```
 
 ### `withReducer()`
 

--- a/src/packages/recompose/withState.js
+++ b/src/packages/recompose/withState.js
@@ -2,7 +2,7 @@ import { Component } from 'react'
 import createHelper from './createHelper'
 import createEagerFactory from './createEagerFactory'
 
-const withState = (stateName, stateUpdaterName, initialState) =>
+const withStateOriginal = (stateName, stateUpdaterName, initialState) =>
   BaseComponent => {
     const factory = createEagerFactory(BaseComponent)
     return class extends Component {
@@ -29,5 +29,35 @@ const withState = (stateName, stateUpdaterName, initialState) =>
       }
     }
   }
+
+const withClasslikeState = (initialState) =>
+  BaseComponent => {
+    const factory = createEagerFactory(BaseComponent)
+    return class extends Component {
+      state = typeof initialState === 'function'
+        ? initialState(this.props)
+        : initialState
+
+      setStateFn = (...args) => {
+        this.setState(...args)
+      }
+
+      render() {
+        return factory({
+          ...this.props,
+          state: this.state,
+          setState: this.setStateFn
+        })
+      }
+    }
+  }
+
+const withState = (...args) => {
+  if (args.length === 1) {
+    return withClasslikeState(...args)
+  }
+
+  return withStateOriginal(...args)
+}
 
 export default createHelper(withState, 'withState')


### PR DESCRIPTION
Adds an additional optional param set for withState, where if you only provide initialState, then stateName and stateUpdaterName are defaulted to 'state' and 'setState'. In this form setState works exactly like setState from a typical class component (because its really just proxying straight to `this.setState`).

Example Usage:
```javascript
import { withState } from 'recompose';

// setting initial state only
const enhance = withState({ red: 0, green: 0, blue: 0 });

// automatically get state and setState props
const RGBChooser = enhance(({ state, setState }) => 
  <div>
    <input type="text" value={ state.red } onChange={ (e) => setState({ red: e.target.value }) } />
    <input type="text" value={ state.green } onChange={ (e) => setState({ green: e.target.value }) } />
    <input type="text" value={ state.blue } onChange={ (e) => setState({ blue: e.target.value }) } /> 
    <div
      style={{
        display: block,
        width: 30,
        height: 30,
        backgroundColor: `rgb(${state.red},${state.green},${state.blue})`
      }}
    /> 
  </div>
);
```
I have code, tests, and docs in this PR.

closes #321