### PR TITLE
Fix jest config to search tests in src folder only

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "jest": {
     "testMatch": [
-      "**/__tests__/**/*-test.js"
+      "<rootDir>/src/**/__tests__/**/*-test.js"
     ],
     "coverageReporters": [
       "text-summary",


### PR DESCRIPTION
For now it tries to run tests in lib folder.