### PR TITLE
Fixed ".babelrc" not being JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ This can be done by updating `lodash` config in `.babelrc`.
  {
 -  "plugins": ["lodash"]
 +  "plugins": [
-+    ["lodash", { id: ["lodash", "recompose"] }]
++    ["lodash", { "id": ["lodash", "recompose"] }]
 +  ]
  }
 ```


### PR DESCRIPTION
My IDE requires `.babelrc` to be of a pure `JSON` format.