### PR TITLE
Change createClass to Component in docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -478,7 +478,7 @@ lifecycle(
 ): HigherOrderComponent
 ```
 
-A higher-order component version of [`React.createClass()`](https://facebook.github.io/react/docs/react-api.html#createclass). It supports the entire `createClass()` API, except the `render()` method, which is implemented by default (and overridden if specified; an error will be logged to the console). You should use this helper as an escape hatch, in case you need to access component lifecycle methods.
+A higher-order component version of [`React.Component()`](https://facebook.github.io/react/docs/react-api.html#react.component). It supports the entire `Component` API, except the `render()` method, which is implemented by default (and overridden if specified; an error will be logged to the console). You should use this helper as an escape hatch, in case you need to access component lifecycle methods.
 
 Any state changes made in a lifecycle method, by using `setState`, will be propagated to the wrapped component as props.
 

--- a/src/packages/recompose/__tests__/lifecycle-test.js
+++ b/src/packages/recompose/__tests__/lifecycle-test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { lifecycle } from '../'
 
-test('lifecycle is a higher-order component version of React.createClass', () => {
+test('lifecycle is a higher-order component version of React.Component', () => {
   const enhance = lifecycle({
     componentWillMount() {
       this.setState({ 'data-bar': 'baz' })


### PR DESCRIPTION
With `v0.23.0` `createClass` was replaced with `Component` but some docs where not updated.