### PR TITLE
Fixed lack of es6 Object.assign in target envs like IE11

### DIFF
--- a/src/packages/recompose/lifecycle.js
+++ b/src/packages/recompose/lifecycle.js
@@ -15,12 +15,6 @@ const lifecycle = spec => BaseComponent => {
   }
 
   class Lifecycle extends Component {
-    constructor(...args) {
-      super(...args)
-
-      Object.assign(this, spec)
-    }
-
     render() {
       return factory({
         ...this.props,
@@ -28,6 +22,8 @@ const lifecycle = spec => BaseComponent => {
       })
     }
   }
+
+  Object.keys(spec).forEach(hook => (Lifecycle.prototype[hook] = spec[hook]))
 
   if (process.env.NODE_ENV !== 'production') {
     return setDisplayName(wrapDisplayName(BaseComponent, 'lifecycle'))(


### PR DESCRIPTION
Fixes 'regression' introduced in - https://github.com/acdlite/recompose/pull/346 , which also should result in some minor perf/memory gain as `spec` gets shared on the prototype now and this needs to be done only once.

cc @istarkov 