### PR TITLE
Create withPropState.js

### DIFF
--- a/src/packages/recompose/withPropState.js
+++ b/src/packages/recompose/withPropState.js
@@ -1,0 +1,43 @@
+import { Component } from 'react'
+import setDisplayName from './setDisplayName'
+import wrapDisplayName from './wrapDisplayName'
+import createEagerFactory from './createEagerFactory'
+
+const withPropState = (stateName, stateUpdaterName, initialState) => {
+  return BaseComponent => {
+    const factory = createEagerFactory(BaseComponent)
+    class WithPropState extends Component {
+      state = {
+        stateValue: typeof initialState === 'function' ? initialState(this.props) : initialState,
+      }
+
+      componentWillReceiveProps(nextProps) {
+        this.setState({ [stateName]: nextProps[stateName] })
+      }
+
+      updateStateValue = (updateFn, callback) =>
+        this.setState(
+          ({ stateValue }) => ({
+            stateValue: typeof updateFn === 'function' ? updateFn(stateValue) : updateFn,
+          }),
+          callback,
+        )
+
+      render() {
+        return factory({
+          ...this.props,
+          [stateName]: this.state.stateValue,
+          [stateUpdaterName]: this.updateStateValue,
+        })
+      }
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      return setDisplayName(wrapDisplayName(BaseComponent, 'withPropState'))(WithPropState)
+    }
+
+    return WithPropState
+  }
+}
+
+export default withPropState


### PR DESCRIPTION
One of the use cases of this is to allow a controlled input to be stored locally in state with an initial value from props. The initial value will most likely be coming from a global store. The user can then have an onBlur of the input field to save the value. If the store is updated via websockets or short/long pulling and the value is saved and stored in the store then this component will reflect that change by updating the local state of `withPropState` in the `componentWillReceiveProps` lifecycle method. This component works just like `withState`, except it updates the state whenever the prop passed in.

Example usage:

```
compose(
  ...
  withPropState('propValue', 'updatePropValue', ({ propValue }) => propValue),
  ...
)
```