### PR TITLE
Run eslint on staged files as part of the precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "lint-staged": {
     "*.js": [
       "prettier --semi false --trailing-comma es5 --single-quote --write",
+      "eslint --fix",
       "git add"
     ]
   },


### PR DESCRIPTION
It will guard contributors before commiting with lint errors. 