### PR TITLE
Allow to call internal handlers within withHandlers

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -129,10 +129,10 @@ Instead of an array of prop keys, the first parameter can also be a function tha
 ```js
 withHandlers(
   handlerCreators: {
-    [handlerName: string]: (props: Object) => Function
+    [handlerName: string]: (props: Object, self: Object) => Function
   } |
   handlerCreatorsFactory: (initialProps) => {
-    [handlerName: string]: (props: Object) => Function
+    [handlerName: string]: (props: Object, self: Object) => Function
   }
 ): HigherOrderComponent
 ```
@@ -143,18 +143,25 @@ This allows the handler to access the current props via closure, without needing
 
 Handlers are passed to the base component as immutable props, whose identities are preserved across renders. This avoids a common pitfall where functional components create handlers inside the body of the function, which results in a new handler on every render and breaks downstream `shouldComponentUpdate()` optimizations that rely on prop equality. This is the main reason to use `withHandlers` to create handlers instead of using `mapProps` or `withProps`, which will create new handlers every time when it get updated.
 
+self argument contains all handlers defined in current enhancer.
+
 Usage example:
 
 ```js
 const enhance = compose(
   withState('value', 'updateValue', ''),
   withHandlers({
-    onChange: props => event => {
-      props.updateValue(event.target.value)
+    onLog: props => message => {
+      console.log(message, props)
     },
-    onSubmit: props => event => {
+    onChange: (props, self) => event => {
+      props.updateValue(event.target.value)
+      self.onLog('onChange')
+    },
+    onSubmit: (props, self) => event => {
       event.preventDefault()
       submitForm(props.value)
+      self.onLog('onSubmit')
     }
   })
 )
@@ -167,6 +174,7 @@ const Form = enhance(({ value, onChange, onSubmit }) =>
   </form>
 )
 ```
+
 
 ### `defaultProps()`
 

--- a/src/packages/recompose/withHandlers.js
+++ b/src/packages/recompose/withHandlers.js
@@ -29,7 +29,7 @@ const withHandlers = handlers => BaseComponent => {
           return cachedHandler(...args)
         }
 
-        const handler = createHandler(this.props)
+        const handler = createHandler(this.props, this.handlers)
         this.cachedHandlers[handlerName] = handler
 
         if (


### PR DESCRIPTION
I like the idea described here #333
BTW seems like author don't want to finish it.

The idea is to allow to call internal handlers within withHandlers, as for now it's not a rare case for me to create a chain of withHandlers just to allow reuse some handlers.

Usage example

```javascript
withHandlers({
    selfHandler: props => val => {
      selfHandlerCallSpy({ props, val })
    },
    handler: (_, { selfHandler }) => val => {
      selfHandler(val) // it works
    },
})
```

Before to do that I did:

```javascript
withHandlers({
    selfHandler: props => val => {
      selfHandlerCallSpy({ props, val })
    },
}),
withHandlers({
    handler: ({ selfHandler }) => val => {
      selfHandler(val) // it works
    },
})
```

BTW I'm not sure do we need this or not, as even I like the idea I'm pretty happy with withHandlers chain