### PR TITLE
Add gitbook for reading docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ release
 lib
 coverage
 .vscode
+_book

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,5 @@
+# Tabel Of Content
+
+* [README](/README.md)
+* [API](/docs/API.md)
+* [Performance](/docs/performance.md)

--- a/book.json
+++ b/book.json
@@ -1,0 +1,17 @@
+{
+  "title": "recompose",
+  "author": "Andrew Clark <acdlite@me.com>",
+  "gitbook": "3.2.0",
+  "plugins": ["prism", "-highlight", "github", "sharing"],
+  "pluginsConfig": {
+    "github": {
+      "url": "https://github.com/acdlite/recompose"
+    },
+    "sharing": {
+      "facebook": true,
+      "twitter": true,
+      "google": false,
+      "weibo": false
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,12 @@
     "release": "node scripts/release.js",
     "postinstall": "node scripts/installNestedPackageDeps.js",
     "format": "prettier --semi false --trailing-comma es5 --single-quote --write 'scripts/*.js' 'src/packages/*/*.js' 'src/packages/*/!(node_modules)/**/*.js'",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "docs:clean": "rimraf _book",
+    "docs:prepare": "gitbook install",
+    "docs:build": "npm run docs:prepare && gitbook build -g acdlite/recompose",
+    "docs:watch": "npm run docs:prepare && gitbook serve",
+    "docs:publish": "npm run docs:clean && npm run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:acdlite/recompose gh-pages --force"
   },
   "jest": {
     "testMatch": [
@@ -58,6 +63,7 @@
     "eslint-plugin-prettier": "^2.0.1",
     "eslint-plugin-react": "^6.10.3",
     "flyd": "^0.2.4",
+    "gitbook-cli": "^2.3.0",
     "husky": "^0.13.3",
     "jest": "^19.0.2",
     "kefir": "^3.2.3",
@@ -70,6 +76,7 @@
     "react-dom": "^15.0.0",
     "react-test-renderer": "^15.5.4",
     "readline-sync": "^1.2.21",
+    "rimraf": "^2.6.1",
     "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",


### PR DESCRIPTION
I think we can deploy docs on gh-page convenient for reading.
If unnecessary, feel free close this PR, thanks.