### PR TITLE
rxjs 5 tree shaking

### DIFF
--- a/src/packages/recompose/__tests__/setObservableConfig-test.js
+++ b/src/packages/recompose/__tests__/setObservableConfig-test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
+import 'rxjs/add/operator/map'
 import rxjs5Config from '../rxjsObservableConfig'
 import rxjs4Config from '../rxjs4ObservableConfig'
 import mostConfig from '../mostObservableConfig'

--- a/src/packages/recompose/rxjsObservableConfig.js
+++ b/src/packages/recompose/rxjsObservableConfig.js
@@ -1,7 +1,7 @@
-import Rx from 'rxjs'
+import { from } from 'rxjs/Observable/from'
 
 const config = {
-  fromESObservable: Rx.Observable.from,
+  fromESObservable: from,
   toESObservable: stream => stream,
 }
 

--- a/src/packages/recompose/rxjsObservableConfig.js
+++ b/src/packages/recompose/rxjsObservableConfig.js
@@ -1,4 +1,4 @@
-import { from } from 'rxjs/Observable/from'
+import { from } from 'rxjs/observable/from'
 
 const config = {
   fromESObservable: from,


### PR DESCRIPTION
Currently, the rxjs config of recompose, for the `mapStreamToProps` and `componentFromStream` enhancers, imports the whole rxjs library. This is quite bad for size-sensitive builds. 

As described [here](https://github.com/ReactiveX/rxjs#installation-and-usage), it is possible to selectively import the features we need from rxjs in order to reduce the build size.

In this PR, I have changed the rxjs 5 config such that only necessary features get imported, dramatically decreasing build size for apps using the enhancers mentioned above with rxjs 5.

In my current app, I have reduced the production build size by **100KB** with this change.