### PR TITLE
effect HOC (rxjs-like 'do') (#426)

### DIFF
--- a/src/packages/recompose/__tests__/effect-test.js
+++ b/src/packages/recompose/__tests__/effect-test.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import sinon from 'sinon'
+import { effect } from '../'
+
+test('effect calls its provided function', () => {
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
+  let external = ''
+
+  const Component = effect(({ foo }) => {
+    external = foo
+  })(component)
+
+  expect(Component.displayName).toBe('effect(component)')
+  mount(<Component foo="bar" />)
+  expect(external).toBe('bar')
+})

--- a/src/packages/recompose/effect.js
+++ b/src/packages/recompose/effect.js
@@ -1,0 +1,17 @@
+import setDisplayName from './setDisplayName'
+import wrapDisplayName from './wrapDisplayName'
+import createEagerFactory from './createEagerFactory'
+
+const effect = (fn = () => {}) => BaseComponent => {
+  const factory = createEagerFactory(BaseComponent)
+  const Effect = props => {
+    fn(props)
+    return factory(props)
+  }
+  if (process.env.NODE_ENV !== 'production') {
+    return setDisplayName(wrapDisplayName(BaseComponent, 'effect'))(Effect)
+  }
+  return Effect
+}
+
+export default effect

--- a/src/packages/recompose/index.js
+++ b/src/packages/recompose/index.js
@@ -1,4 +1,5 @@
 // Higher-order component helpers
+export { default as effect } from './effect'
 export { default as mapProps } from './mapProps'
 export { default as withProps } from './withProps'
 export { default as withPropsOnChange } from './withPropsOnChange'


### PR DESCRIPTION
https://github.com/acdlite/recompose/issues/426

A passthrough HOC that doesn't do anything to the component. just a hook to inspect props or do some other effect.

Will updated the docs if you guys actually want this. I know I would use it a lot