### PR TITLE
Update functional component flowtype

### DIFF
--- a/types/flow-typed/recompose_v0.24.x-/flow_v0.49.x-/recompose_v0.24.x-.js
+++ b/types/flow-typed/recompose_v0.24.x-/flow_v0.49.x-/recompose_v0.24.x-.js
@@ -65,7 +65,7 @@ declare module 'recompose' {
     v: (props: Enhanced) => V
   ) => V
 
-  declare type FunctionComponent<A> = (props: A) => ?React$Element<any>
+  declare type FunctionComponent<A> = (props: A, context?: any) => ?React$Element<any>
 
   declare type ClassComponent<D, A, S> = Class<React$Component<D, A, S>>
 


### PR DESCRIPTION
Some of our functional components take `(props, context)`, confusing the type signature of `FunctionComponent`.