### PR TITLE
Flatten only certain fields (optionally)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -207,7 +207,8 @@ Renames multiple props, using a map of old prop names to new prop names.
 
 ```js
 flattenProp(
-  propName: string
+  propName: string,
+  fields: ?Array<string>
 ): HigherOrderComponent
 ```
 
@@ -224,6 +225,21 @@ const enhance = compose(
 const Abc = enhance(BaseComponent)
 
 // Base component receives props: { a: 'a', b: 'b', c: 'c', object: { a: 'a', b: 'b' } }
+```
+
+Or, if you only want to flatten certain fields, you can specify an array of fields as a second parameter.
+In this case, it will only flatten the fields `a`.
+```js
+const enhance = compose(
+  withProps({
+    object: { a: 'a', b: 'b' },
+    c: 'c'
+  }),
+  flattenProp('object', ['a'])
+)
+const Ac = enhance(BaseComponent)
+
+// Base component receives props: { a: 'a', c: 'c', object: { a: 'a', b: 'b' } }
 ```
 
 An example use case for `flattenProp()` is when receiving fragment data from Relay. Relay fragments are passed as an object of props, which you often want flattened out into its constituent fields:

--- a/src/packages/recompose/__tests__/flattenProp-test.js
+++ b/src/packages/recompose/__tests__/flattenProp-test.js
@@ -26,3 +26,28 @@ test('flattenProps flattens an object prop and spreads it into the top-level pro
   })
   expect(wrapper.equals(<div data-pass="through" data-state={1} />)).toBe(true)
 })
+
+test('flattenProps flattens an object prop and spreads it into the top-level props object (w/keys)', () => {
+  const Counter = flattenProp('data-state', ['data-counter'])('div')
+  expect(Counter.displayName).toBe('flattenProp(div)')
+
+  const dataState = { foo: 'bar', 'data-counter': 1 }
+
+  const wrapper = shallow(
+    <Counter data-pass="through" data-state={dataState} />
+  )
+
+  expect(
+    wrapper.equals(
+      <div data-pass="through" data-state={dataState} data-counter={1} />
+    )
+  ).toBe(true)
+
+  wrapper.setProps({
+    'data-pass': 'through',
+    'data-state': { 'data-state': 1 },
+  })
+  expect(
+    wrapper.equals(<div data-pass="through" data-state={{ 'data-state': 1 }} />)
+  ).toBe(true)
+})

--- a/src/packages/recompose/flattenProp.js
+++ b/src/packages/recompose/flattenProp.js
@@ -1,13 +1,14 @@
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 import createEagerFactory from './createEagerFactory'
+import pick from './utils/pick'
 
-const flattenProp = propName => BaseComponent => {
+const flattenProp = (propName, keys) => BaseComponent => {
   const factory = createEagerFactory(BaseComponent)
   const FlattenProp = props =>
     factory({
       ...props,
-      ...props[propName],
+      ...(keys ? pick(props[propName], keys) : props[propName]),
     })
 
   if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
For your consideration...

Adds an optional second parameter to `flattenProp`. If specified, only the fields specified in the array are flattened.

```js
flattenProp(
  propName: string,
  fields: ?Array<string>
): HigherOrderComponent
```

For example:
```js
const enhance = compose(
  withProps({
    object: { a: 'a', b: 'b' },
    c: 'c'
  }),
  flattenProp('object', ['a'])
)
const Ac = enhance(BaseComponent)

```
Base component receives props: { a: 'a', c: 'c', object: { a: 'a', b: 'b' } }

Added tests and updated docs.
