### PR TITLE
Simpler classful component check (fixes #458)

### DIFF
--- a/src/packages/recompose/isClassComponent.js
+++ b/src/packages/recompose/isClassComponent.js
@@ -2,7 +2,7 @@ const isClassComponent = Component =>
   Boolean(
     Component &&
       Component.prototype &&
-      typeof Component.prototype.isReactComponent === 'object'
+      typeof Component.prototype.render === 'function'
   )
 
 export default isClassComponent


### PR DESCRIPTION
Instead of checking for the `isReactComponent` property (which is internal to React), it seems advantageous to check for `render()`. This improves Preact support (when using recompose with non-preact-compat components) but also importantly works with components that don't inherit from `Component`.