### PR TITLE
Use eager factory optimization only in production env (close #442)

### DIFF
--- a/src/packages/recompose/__tests__/createElement-test.js
+++ b/src/packages/recompose/__tests__/createElement-test.js
@@ -2,6 +2,12 @@ import React, { Component } from 'react'
 import { shallow } from 'enzyme'
 import createEagerElement from '../createEagerElement'
 
+const origNodeEnv = process.env.NODE_ENV
+
+afterEach(() => {
+  process.env.NODE_ENV = origNodeEnv
+})
+
 test('createEagerElement treats class components normally', () => {
   class InnerDiv extends Component {
     render() {
@@ -31,6 +37,7 @@ test('createEagerElement treats class components normally', () => {
 })
 
 test('createEagerElement calls stateless function components instead of creating an intermediate React element', () => {
+  process.env.NODE_ENV = 'production'
   const InnerDiv = () => <div data-bar="baz" />
   const OuterDiv = () =>
     createEagerElement(
@@ -64,6 +71,7 @@ test('createEagerElement handles keyed elements correctly', () => {
 })
 
 test('createEagerElement passes children correctly', () => {
+  process.env.NODE_ENV = 'production'
   const Div = props => <div {...props} />
   const InnerDiv = () => <div data-bar="baz" />
   const OuterDiv = () =>

--- a/src/packages/recompose/__tests__/hoistStatics-test.js
+++ b/src/packages/recompose/__tests__/hoistStatics-test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import sinon from 'sinon'
 import { hoistStatics, mapProps } from '../'
 
@@ -13,6 +13,6 @@ test('copies non-React static properties from base component to new component', 
 
   expect(EnhancedComponent.foo).toBe(BaseComponent.foo)
 
-  shallow(<EnhancedComponent n={3} />)
+  mount(<EnhancedComponent n={3} />)
   expect(BaseComponent.firstCall.args[0].n).toBe(15)
 })

--- a/src/packages/recompose/__tests__/isReferentiallyTransparentFunctionComponent-test.js
+++ b/src/packages/recompose/__tests__/isReferentiallyTransparentFunctionComponent-test.js
@@ -3,25 +3,11 @@ import createReactClass from 'create-react-class'
 import PropTypes from 'prop-types'
 import isReferentiallyTransparentFunctionComponent from '../isReferentiallyTransparentFunctionComponent'
 
-const origNodeEnv = process.env.NODE_ENV
-
-afterEach(() => {
-  process.env.NODE_ENV = origNodeEnv
-})
-
-test('isReferentiallyTransparentFunctionComponent returns false in non-production env', () => {
-  const Foo = props => <div {...props} />
-
-  expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(false)
-})
-
 test('isReferentiallyTransparentFunctionComponent returns false for strings', () => {
   expect(isReferentiallyTransparentFunctionComponent('div')).toBe(false)
 })
 
 test('isReferentiallyTransparentFunctionComponent returns false for class components', () => {
-  process.env.NODE_ENV = 'production'
-
   class Foo extends Component {
     render() {
       return <div />
@@ -41,14 +27,12 @@ test('isReferentiallyTransparentFunctionComponent returns false for class compon
 })
 
 test('isReferentiallyTransparentFunctionComponent returns true for functions', () => {
-  process.env.NODE_ENV = 'production'
   const Foo = props => <div {...props} />
 
   expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(true)
 })
 
 test('isReferentiallyTransparentFunctionComponent returns false for functions that use context', () => {
-  process.env.NODE_ENV = 'production'
   const Foo = (props, context) => <div {...props} {...context} />
   Foo.contextTypes = { store: PropTypes.object }
 
@@ -56,17 +40,15 @@ test('isReferentiallyTransparentFunctionComponent returns false for functions th
 })
 
 test('isReferentiallyTransparentFunctionComponent returns false for functions that use default props', () => {
-  process.env.NODE_ENV = 'production'
   const Foo = (props, context) => <div {...props} {...context} />
   Foo.defaultProps = { store: PropTypes.object }
 
   expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(false)
 })
 
-test('isReferentiallyTransparentFunctionComponent returns true for functions that use propTypes', () => {
-  process.env.NODE_ENV = 'production'
+test('isReferentiallyTransparentFunctionComponent returns false for functions that use propTypes', () => {
   const Foo = (props, context) => <div {...props} {...context} />
   Foo.propTypes = { store: PropTypes.object }
 
-  expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(true)
+  expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(false)
 })

--- a/src/packages/recompose/__tests__/isReferentiallyTransparentFunctionComponent-test.js
+++ b/src/packages/recompose/__tests__/isReferentiallyTransparentFunctionComponent-test.js
@@ -46,9 +46,9 @@ test('isReferentiallyTransparentFunctionComponent returns false for functions th
   expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(false)
 })
 
-test('isReferentiallyTransparentFunctionComponent returns false for functions that use propTypes', () => {
+test('isReferentiallyTransparentFunctionComponent returns true for functions that use propTypes', () => {
   const Foo = (props, context) => <div {...props} {...context} />
   Foo.propTypes = { store: PropTypes.object }
 
-  expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(false)
+  expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(true)
 })

--- a/src/packages/recompose/__tests__/isReferentiallyTransparentFunctionComponent-test.js
+++ b/src/packages/recompose/__tests__/isReferentiallyTransparentFunctionComponent-test.js
@@ -3,11 +3,25 @@ import createReactClass from 'create-react-class'
 import PropTypes from 'prop-types'
 import isReferentiallyTransparentFunctionComponent from '../isReferentiallyTransparentFunctionComponent'
 
+const origNodeEnv = process.env.NODE_ENV
+
+afterEach(() => {
+  process.env.NODE_ENV = origNodeEnv
+})
+
+test('isReferentiallyTransparentFunctionComponent returns false in non-production env', () => {
+  const Foo = props => <div {...props} />
+
+  expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(false)
+})
+
 test('isReferentiallyTransparentFunctionComponent returns false for strings', () => {
   expect(isReferentiallyTransparentFunctionComponent('div')).toBe(false)
 })
 
 test('isReferentiallyTransparentFunctionComponent returns false for class components', () => {
+  process.env.NODE_ENV = 'production'
+
   class Foo extends Component {
     render() {
       return <div />
@@ -27,12 +41,14 @@ test('isReferentiallyTransparentFunctionComponent returns false for class compon
 })
 
 test('isReferentiallyTransparentFunctionComponent returns true for functions', () => {
+  process.env.NODE_ENV = 'production'
   const Foo = props => <div {...props} />
 
   expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(true)
 })
 
 test('isReferentiallyTransparentFunctionComponent returns false for functions that use context', () => {
+  process.env.NODE_ENV = 'production'
   const Foo = (props, context) => <div {...props} {...context} />
   Foo.contextTypes = { store: PropTypes.object }
 
@@ -40,15 +56,17 @@ test('isReferentiallyTransparentFunctionComponent returns false for functions th
 })
 
 test('isReferentiallyTransparentFunctionComponent returns false for functions that use default props', () => {
+  process.env.NODE_ENV = 'production'
   const Foo = (props, context) => <div {...props} {...context} />
   Foo.defaultProps = { store: PropTypes.object }
 
   expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(false)
 })
 
-test('isReferentiallyTransparentFunctionComponent returns false for functions that use propTypes', () => {
+test('isReferentiallyTransparentFunctionComponent returns true for functions that use propTypes', () => {
+  process.env.NODE_ENV = 'production'
   const Foo = (props, context) => <div {...props} {...context} />
   Foo.propTypes = { store: PropTypes.object }
 
-  expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(false)
+  expect(isReferentiallyTransparentFunctionComponent(Foo)).toBe(true)
 })

--- a/src/packages/recompose/__tests__/renameProp-test.js
+++ b/src/packages/recompose/__tests__/renameProp-test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import { withProps, renameProp, compose } from '../'
 
 test('renameProp renames a single prop', () => {
@@ -10,6 +10,6 @@ test('renameProp renames a single prop', () => {
 
   expect(StringConcat.displayName).toBe('withProps(renameProp(div))')
 
-  const div = shallow(<StringConcat />).find('div')
+  const div = mount(<StringConcat />).find('div')
   expect(div.props()).toEqual({ 'data-do': 123, 'data-la': 456 })
 })

--- a/src/packages/recompose/__tests__/renameProps-test.js
+++ b/src/packages/recompose/__tests__/renameProps-test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import { withProps, renameProps, compose } from '../'
 
 test('renameProps renames props', () => {
@@ -10,7 +10,7 @@ test('renameProps renames props', () => {
 
   expect(StringConcat.displayName).toBe('withProps(renameProps(div))')
 
-  const div = shallow(<StringConcat />).find('div')
+  const div = mount(<StringConcat />).find('div')
 
   expect(div.prop('data-do')).toBe(123)
   expect(div.prop('data-fa')).toBe(456)

--- a/src/packages/recompose/isReferentiallyTransparentFunctionComponent.js
+++ b/src/packages/recompose/isReferentiallyTransparentFunctionComponent.js
@@ -2,9 +2,9 @@ import isClassComponent from './isClassComponent'
 
 const isReferentiallyTransparentFunctionComponent = Component =>
   Boolean(
-    process.env.NODE_ENV === 'production' &&
-      typeof Component === 'function' &&
+    typeof Component === 'function' &&
       !isClassComponent(Component) &&
+      !Component.propTypes &&
       !Component.defaultProps &&
       !Component.contextTypes
   )

--- a/src/packages/recompose/isReferentiallyTransparentFunctionComponent.js
+++ b/src/packages/recompose/isReferentiallyTransparentFunctionComponent.js
@@ -4,7 +4,6 @@ const isReferentiallyTransparentFunctionComponent = Component =>
   Boolean(
     typeof Component === 'function' &&
       !isClassComponent(Component) &&
-      !Component.propTypes &&
       !Component.defaultProps &&
       !Component.contextTypes
   )

--- a/src/packages/recompose/isReferentiallyTransparentFunctionComponent.js
+++ b/src/packages/recompose/isReferentiallyTransparentFunctionComponent.js
@@ -2,11 +2,11 @@ import isClassComponent from './isClassComponent'
 
 const isReferentiallyTransparentFunctionComponent = Component =>
   Boolean(
-    typeof Component === 'function' &&
+    process.env.NODE_ENV === 'production' &&
+      typeof Component === 'function' &&
       !isClassComponent(Component) &&
       !Component.defaultProps &&
-      !Component.contextTypes &&
-      (process.env.NODE_ENV === 'production' || !Component.propTypes)
+      !Component.contextTypes
   )
 
 export default isReferentiallyTransparentFunctionComponent

--- a/src/packages/recompose/utils/createEagerElementUtil.js
+++ b/src/packages/recompose/utils/createEagerElementUtil.js
@@ -7,7 +7,11 @@ const createEagerElementUtil = (
   props,
   children
 ) => {
-  if (!hasKey && isReferentiallyTransparent) {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    !hasKey &&
+    isReferentiallyTransparent
+  ) {
     if (children) {
       return type({ ...props, children })
     }


### PR DESCRIPTION
As discussed in #442.

* We don't care about `propTypes` check anymore since it's already no-op in prod env.
* Notice few `shallow` → `mount` changes in tests – that's actually the confusion which I described in corresponding issue.

:v: 