### PR TITLE
Updated jsfiddle example base link. Fixes #486

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Recompose is a React utility belt for function components and higher-order compo
 
 [**Full API documentation**](docs/API.md) - Learn about each helper
 
-[**Recompose Base Fiddle**](https://jsfiddle.net/acdlite/69z2wepo/41596/) - Easy way to dive in
+[**Recompose Base Fiddle**](https://jsfiddle.net/samsch/p3vsmrvo/2/) - Easy way to dive in
 
 ```
 npm install recompose --save


### PR DESCRIPTION
New jsfiddle uses built-in babel mode with syntax highlighting, as mentioned in #486.

This new fiddle uses the latest version of Recompose, and the example uses `withStateHandlers` rather than `compose`, `withState`, and `withHandlers`.

Code formatted externally with Prettier (default config, using online sandbox).