### PR TITLE
hoist-non-react-statics@2.3.1

### DIFF
--- a/src/packages/recompose/package.json
+++ b/src/packages/recompose/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "change-emitter": "^0.1.2",
     "fbjs": "^0.8.1",
-    "hoist-non-react-statics": "^1.0.0",
+    "hoist-non-react-statics": "^2.3.1",
     "symbol-observable": "^1.0.4"
   },
   "peerDependencies": {

--- a/src/packages/recompose/yarn.lock
+++ b/src/packages/recompose/yarn.lock
@@ -32,9 +32,9 @@ fbjs@^0.8.1:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-hoist-non-react-statics@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+hoist-non-react-statics@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
 iconv-lite@~0.4.13:
   version "0.4.18"


### PR DESCRIPTION
Updates hoist-non-react-statics to version 2. This brings the version range in line with react-redux's dependency on hoist-non-react-statics, allowing build tooling to dedupe and produce smaller bundles.