### PR TITLE
Updated base fiddle link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Recompose is a React utility belt for function components and higher-order compo
 
 [**Full API documentation**](docs/API.md) - Learn about each helper
 
-[**Recompose Base Fiddle**](https://jsfiddle.net/samsch/p3vsmrvo/2/) - Easy way to dive in
+[**Recompose Base Fiddle**](https://jsfiddle.net/samsch/p3vsmrvo/24/) - Easy way to dive in
 
 ```
 npm install recompose --save


### PR DESCRIPTION
Base fiddle was using a unpkg link pointed at the old (React 15) dist url but without a React version, so broke with the release of React 16. Now points to the correct location for React 16, with 16 specified (shouldn't break this way again).