### PR TITLE
add optional ability for lifecycle to take fn

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -524,13 +524,15 @@ Gets values from context and passes them along as props. Use along with `withCon
 
 ```js
 lifecycle(
-  spec: Object,
+  spec: Object || spec: (props: Object) => Object
 ): HigherOrderComponent
 ```
 
 A higher-order component version of [`React.Component()`](https://facebook.github.io/react/docs/react-api.html#react.component). It supports the entire `Component` API, except the `render()` method, which is implemented by default (and overridden if specified; an error will be logged to the console). You should use this helper as an escape hatch, in case you need to access component lifecycle methods.
 
 Any state changes made in a lifecycle method, by using `setState`, will be propagated to the wrapped component as props.
+
+You may also pass in a function that receives props from parent higher order components, to create the object of lifecycle methods.
 
 ### `toClass()`
 

--- a/src/packages/recompose/__tests__/lifecycle-test.js
+++ b/src/packages/recompose/__tests__/lifecycle-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import { lifecycle } from '../'
+import { lifecycle, compose, withProps } from '../'
 
 test('lifecycle is a higher-order component version of React.Component', () => {
   const enhance = lifecycle({
@@ -14,4 +14,27 @@ test('lifecycle is a higher-order component version of React.Component', () => {
   const div = mount(<Div data-foo="bar" />).find('div')
   expect(div.prop('data-foo')).toBe('bar')
   expect(div.prop('data-bar')).toBe('baz')
+})
+
+test('lifecycle can take fn that has props to generate hooks', () => {
+  const enhance = compose(
+    withProps({
+      'data-test': 30,
+    }),
+    lifecycle(props => ({
+      componentWillMount() {
+        this.setState({
+          'data-bar': 'baz',
+          'data-test': props['data-test'] * 3,
+        })
+      },
+    }))
+  )
+  const Div = enhance('div')
+  expect(Div.displayName).toBe('withProps(lifecycle(div))')
+
+  const div = mount(<Div data-foo="bar" />).find('div')
+  expect(div.prop('data-foo')).toBe('bar')
+  expect(div.prop('data-bar')).toBe('baz')
+  expect(div.prop('data-test')).toBe(90)
 })

--- a/src/packages/recompose/lifecycle.js
+++ b/src/packages/recompose/lifecycle.js
@@ -5,6 +5,16 @@ import wrapDisplayName from './wrapDisplayName'
 
 const lifecycle = spec => BaseComponent => {
   const factory = createFactory(BaseComponent)
+  const specIsFn = typeof spec === 'function'
+
+  class LifecycleFnWrapper extends Component {
+    render() {
+      return factory({
+        ...this.props,
+        ...this.state,
+      })
+    }
+  }
 
   if (process.env.NODE_ENV !== 'production' && spec.hasOwnProperty('render')) {
     console.error(
@@ -14,15 +24,37 @@ const lifecycle = spec => BaseComponent => {
   }
 
   class Lifecycle extends Component {
+    setFactory() {
+      // if the spec that was passed in is a function that
+      // returns the spec for lifecycle methods, use thewrapper
+      // component for the BaseComponent, otherwise use the BaseComonent
+      if (specIsFn) {
+        const wrapperSpec = spec(this.props)
+        Object.keys(wrapperSpec).forEach(hook => {
+          LifecycleFnWrapper.prototype[hook] = wrapperSpec[hook]
+        })
+        this.factoryToUse = createFactory(LifecycleFnWrapper)
+      } else {
+        this.factoryToUse = factory
+      }
+    }
     render() {
-      return factory({
+      if (!this.factoryToUse) {
+        this.setFactory()
+      }
+      return this.factoryToUse({
         ...this.props,
         ...this.state,
       })
     }
   }
 
-  Object.keys(spec).forEach(hook => (Lifecycle.prototype[hook] = spec[hook]))
+  // if the spec we got was a normal object, attach the hooks here
+  if (!specIsFn) {
+    Object.keys(spec).forEach(hook => {
+      Lifecycle.prototype[hook] = spec[hook]
+    })
+  }
 
   if (process.env.NODE_ENV !== 'production') {
     return setDisplayName(wrapDisplayName(BaseComponent, 'lifecycle'))(


### PR DESCRIPTION
that also has props bound, this will allow lifecycle methods to make use
of parent props, instead of needing to rely on closures to apply things
ToDo before merging
[x] add documentation