### PR TITLE
Add ability to pass handler methods to all handler factory methods

### DIFF
--- a/src/packages/recompose/withHandlers.js
+++ b/src/packages/recompose/withHandlers.js
@@ -17,7 +17,10 @@ const withHandlers = handlers => BaseComponent => {
           return cachedHandler(...args)
         }
 
-        const handler = createHandler(this.props)
+        const handler = createHandler({
+          ...this.handlers,
+          ...this.props,
+        })
         this.cachedHandlers[handlerName] = handler
 
         if (


### PR DESCRIPTION
This makes it easy to reference other handlers from within the body of a handler.  To achieve this functionality currently you would have to compose your handlers in the correct dependency order.  If a circular handler dependency was ever needed then that would not have previously been possible.

The one "tricky" part is what to do when there are prop-handler name collisions.  I decided that passed props should have priority over handlers when passed to the handler factory.