### PR TITLE
Added withPropChangeHandler

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -37,6 +37,7 @@ const PureComponent = pure(BaseComponent)
   + [`mapProps()`](#mapprops)
   + [`withProps()`](#withprops)
   + [`withPropsOnChange()`](#withpropsonchange)
+  + [`withPropChangeHandler()`](#withpropchangehandler)
   + [`withHandlers()`](#withhandlers)
   + [`defaultProps()`](#defaultprops)
   + [`renameProp()`](#renameprop)
@@ -125,6 +126,56 @@ withPropsOnChange(
 Like `withProps()`, except the new props are only created when one of the owner props specified by `shouldMapOrKeys` changes. This helps ensure that expensive computations inside `createProps()` are only executed when necessary.
 
 Instead of an array of prop keys, the first parameter can also be a function that returns a boolean, given the current props and the next props. This allows you to customize when `createProps()` should be called.
+
+### `withPropChangeHandler()`
+
+```js
+withPropChangeHandler(
+  keys: Array<string> | null,
+  propChangeHandler: (nextProps:Object, previousProps:Object) => void
+): HigherOrderComponent
+```
+
+Calls the handler function if any of the props that are specified in the first parameter change.
+
+If the first parameter is null, the handler will be called on every change.
+
+The handler will be called
+ * before mount with an empty object as previousProps,
+ * on prop change with the next and previous props,
+ * before unmount with an empty object as nextProps.
+
+Usage example:
+
+```js
+const enhance = withPropChangeHandler(
+  ['groupId', 'userId'],
+  (
+    { groupId, userId, loadPosts },
+    { groupId: previousGroupId, userId: previousUserId, unloadPosts }
+  ) => {
+    if (previousGroupId && previousUserId) {
+      unloadPosts(previousGroupId, previousUserId)
+    }
+
+    if (groupId && userId) {
+      loadPosts(groupId, userId)
+    }
+  }
+)
+
+const Posts = enhance(
+  ({ posts }) =>
+    posts &&
+    <div>
+      {posts.map(({ id, content }) =>
+        <div key={id}>
+          {content}
+        </div>
+      )}
+    </div>
+)
+```
 
 ### `withHandlers()`
 

--- a/src/packages/recompose/__tests__/withPropChangeHandler-test.js
+++ b/src/packages/recompose/__tests__/withPropChangeHandler-test.js
@@ -1,0 +1,132 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import sinon from 'sinon'
+import { withPropChangeHandler } from '../'
+
+test('withPropChangeHandler sets the proper displayName', () => {
+  const component = () => null
+  component.displayName = 'component'
+
+  const ComponentWithPropChangeHandler = withPropChangeHandler(() => null)(
+    component
+  )
+
+  expect(ComponentWithPropChangeHandler.displayName).toBe(
+    'withPropChangeHandler(component)'
+  )
+})
+
+test('withPropChangeHandler renders the base component', () => {
+  const component = sinon.spy(() => null)
+
+  const SpyWithPropChangeHandler = withPropChangeHandler(
+    ['a', 'b'],
+    () => null
+  )(component)
+
+  const wrapper = mount(<SpyWithPropChangeHandler a={1} b={1} />)
+  wrapper.setProps({ b: undefined })
+  wrapper.setProps({ c: 1 })
+  expect(component.args[0][0]).toEqual({ a: 1, b: 1 })
+  expect(component.args[1][0]).toEqual({ a: 1 })
+  expect(component.args[2][0]).toEqual({ a: 1, c: 1 })
+  wrapper.unmount()
+})
+
+test('withPropChangeHandler calls propChangeHandler on every change if keys argument is null', () => {
+  const component = sinon.spy(() => null)
+
+  const propChangeHandler = sinon.spy()
+
+  const SpyWithPropChangeHandler = withPropChangeHandler(
+    null,
+    propChangeHandler
+  )(component)
+
+  expect(propChangeHandler.callCount).toBe(0)
+
+  const wrapper = mount(<SpyWithPropChangeHandler a={1} b={1} />)
+
+  expect(propChangeHandler.callCount).toBe(1)
+  expect(propChangeHandler.args[0]).toEqual([{ a: 1, b: 1 }, {}])
+
+  wrapper.setProps({ b: undefined })
+
+  expect(propChangeHandler.callCount).toBe(2)
+  expect(propChangeHandler.args[1]).toEqual([{ a: 1 }, { a: 1, b: 1 }])
+
+  wrapper.setProps({ c: 1 })
+
+  expect(propChangeHandler.callCount).toBe(3)
+  expect(propChangeHandler.args[2]).toEqual([{ a: 1, c: 1 }, { a: 1 }])
+
+  wrapper.setProps({ c: 1 })
+
+  expect(propChangeHandler.callCount).toBe(3)
+
+  wrapper.unmount()
+
+  expect(propChangeHandler.callCount).toBe(4)
+  expect(propChangeHandler.args[3]).toEqual([{}, { a: 1, c: 1 }])
+})
+
+test('withPropChangeHandler calls propChangeHandler only when the specified props change', () => {
+  const component = sinon.spy(() => null)
+
+  const propChangeHandler = sinon.spy()
+
+  const SpyWithPropChangeHandler = withPropChangeHandler(
+    ['a', 'b'],
+    propChangeHandler
+  )(component)
+
+  expect(propChangeHandler.callCount).toBe(0)
+
+  const wrapper = mount(<SpyWithPropChangeHandler a={1} b={1} />)
+
+  expect(propChangeHandler.callCount).toBe(1)
+  expect(propChangeHandler.args[0]).toEqual([{ a: 1, b: 1 }, {}])
+
+  wrapper.setProps({ b: 2 })
+
+  expect(propChangeHandler.callCount).toBe(2)
+  expect(propChangeHandler.args[1]).toEqual([{ a: 1, b: 2 }, { a: 1, b: 1 }])
+
+  wrapper.setProps({ a: 3, b: 3 })
+
+  expect(propChangeHandler.callCount).toBe(3)
+  expect(propChangeHandler.args[2]).toEqual([{ a: 3, b: 3 }, { a: 1, b: 2 }])
+
+  wrapper.setProps({ a: 3 })
+
+  expect(propChangeHandler.callCount).toBe(3)
+
+  wrapper.setProps({ c: 1, d: 1 })
+
+  expect(propChangeHandler.callCount).toBe(3)
+
+  wrapper.setProps({ d: undefined })
+
+  expect(propChangeHandler.callCount).toBe(3)
+
+  wrapper.setProps({ b: undefined })
+
+  expect(propChangeHandler.callCount).toBe(4)
+  expect(propChangeHandler.args[3]).toEqual([
+    { a: 3, c: 1 },
+    { a: 3, b: 3, c: 1 },
+  ])
+
+  wrapper.setProps({ b: 3 })
+
+  expect(propChangeHandler.callCount).toBe(5)
+  expect(propChangeHandler.args[4]).toEqual([
+    { a: 3, b: 3, c: 1 },
+    { a: 3, c: 1 },
+  ])
+
+  wrapper.unmount()
+
+  expect(propChangeHandler.callCount).toBe(6)
+  expect(propChangeHandler.args[5]).toEqual([{}, { a: 3, b: 3, c: 1 }])
+})

--- a/src/packages/recompose/index.js
+++ b/src/packages/recompose/index.js
@@ -2,6 +2,7 @@
 export { default as mapProps } from './mapProps'
 export { default as withProps } from './withProps'
 export { default as withPropsOnChange } from './withPropsOnChange'
+export { default as withPropChangeHandler } from './withPropChangeHandler'
 export { default as withHandlers } from './withHandlers'
 export { default as defaultProps } from './defaultProps'
 export { default as renameProp } from './renameProp'

--- a/src/packages/recompose/withPropChangeHandler.js
+++ b/src/packages/recompose/withPropChangeHandler.js
@@ -1,0 +1,46 @@
+import { createFactory, Component } from 'react'
+import setDisplayName from './setDisplayName'
+import wrapDisplayName from './wrapDisplayName'
+
+const withPropChangeHandler = (keys, propChangeHandler) => BaseComponent => {
+  const factory = createFactory(BaseComponent)
+
+  class WithPropChangeHandler extends Component {
+    componentWillMount() {
+      propChangeHandler(this.props, {})
+    }
+
+    componentWillReceiveProps(nextProps) {
+      const { props } = this
+
+      const keysToCompare =
+        keys || Object.keys(nextProps).concat(Object.keys(props))
+
+      const propChanged = keysToCompare
+        .map(key => nextProps[key] !== props[key])
+        .reduce((a, b) => a || b, false)
+
+      if (propChanged) {
+        propChangeHandler(nextProps, props)
+      }
+    }
+
+    componentWillUnmount() {
+      propChangeHandler({}, this.props)
+    }
+
+    render() {
+      return factory(this.props)
+    }
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    return setDisplayName(
+      wrapDisplayName(BaseComponent, 'withPropChangeHandler')
+    )(WithPropChangeHandler)
+  }
+
+  return WithPropChangeHandler
+}
+
+export default withPropChangeHandler


### PR DESCRIPTION
I added a new helper called withPropChangeHandler, which can be used for reflecting to the changes of specified props, including mount and unmount.

My intention to add this was to eliminate the need of component classes, when we need them only for loading and unloading resources based on props (e.g. react router params). When the component does not get remounted, but only the props change I have to include the componentWillReceiveProps method too to handle the transition between pages, which adds unnecessary complexity. 

With this helper the transitions can be solved with one function which loads and unloads resources based on the presence and content of the specified props.