### PR TITLE
Add onChange()

### DIFF
--- a/src/packages/recompose/__tests__/onChange-test.js
+++ b/src/packages/recompose/__tests__/onChange-test.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import sinon from 'sinon'
+import { onChange, withState, compose } from '../'
+
+test('onChange', () => {
+  const spy = sinon.spy()
+
+  const Counter = compose(
+    withState('counter', 'updateCounter', 0),
+    withState('name', 'updateName', 'Alexander'),
+    onChange('counter', spy)
+  )(({ counter }) =>
+    <div>
+      {counter}
+    </div>
+  )
+
+  mount(<Counter />)
+
+  sinon.assert.calledWith(spy, {
+    counter: 0,
+    name: 'Alexander',
+    updateName: sinon.match.func,
+    updateCounter: sinon.match.func,
+  })
+  expect(spy.callCount).toBe(1)
+
+  const initProps = spy.lastCall.args[0]
+  const { updateCounter, updateName } = initProps
+
+  updateCounter(5)
+  expect(spy.secondCall.args[0]).toEqual({ ...initProps, counter: 5 })
+
+  updateName('Andrew')
+  expect(spy.callCount).toBe(2)
+
+  updateCounter(10)
+  expect(spy.thirdCall.args[0]).toEqual({
+    ...initProps,
+    name: 'Andrew',
+    counter: 10,
+  })
+})

--- a/src/packages/recompose/index.js
+++ b/src/packages/recompose/index.js
@@ -20,6 +20,7 @@ export { default as onlyUpdateForPropTypes } from './onlyUpdateForPropTypes'
 export { default as withContext } from './withContext'
 export { default as getContext } from './getContext'
 export { default as lifecycle } from './lifecycle'
+export { default as onChange } from './onChange'
 export { default as toClass } from './toClass'
 
 // Static property helpers

--- a/src/packages/recompose/onChange.js
+++ b/src/packages/recompose/onChange.js
@@ -1,0 +1,39 @@
+import { createFactory, Component } from 'react'
+import setDisplayName from './setDisplayName'
+import wrapDisplayName from './wrapDisplayName'
+import shallowEqual from './shallowEqual'
+
+const onChange = (
+  propName,
+  callback,
+  arePropEqual = shallowEqual
+) => BaseComponent => {
+  const factory = createFactory(BaseComponent)
+
+  class OnChange extends Component {
+    componentDidMount() {
+      if (this.props.hasOwnProperty(propName)) {
+        callback(this.props)
+      }
+    }
+
+    componentWillReceiveProps(nextProps) {
+      if (!arePropEqual(nextProps[propName], this.props[propName])) {
+        callback(nextProps)
+      }
+    }
+
+    render() {
+      return factory({
+        ...this.props,
+      })
+    }
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    return setDisplayName(wrapDisplayName(BaseComponent, 'onChange'))(OnChange)
+  }
+  return OnChange
+}
+
+export default onChange


### PR DESCRIPTION
I think it will be a very useful HOC.
In our project we have a lot of cases when we have to react on property changing. 
Examples:
- A container component has a property - *id*. It has to fetch a new document when *id* has been changed.
- We use redux-form and we have related fields. If some field has been changed, the other has to be changed according to the complicated rule.