### PR TITLE
add lifecycle example in docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -532,6 +532,21 @@ A higher-order component version of [`React.Component()`](https://facebook.githu
 
 Any state changes made in a lifecycle method, by using `setState`, will be propagated to the wrapped component as props.
 
+Example:
+```js
+const PostsList = ({ posts }) => (
+  <ul>{posts.map(p => <li>{p.title}</li>)}</ul>
+)
+
+const PostsListWithData = lifecycle({
+  componentDidMount() {
+    fetchPosts().then(posts => {
+      this.setState({ posts });
+    })
+  }
+})(PostsList);
+```
+
 ### `toClass()`
 
 ```js


### PR DESCRIPTION
Hello,

What do you think about adding example for `lifecycle` usage. When I first used it, it wasn't clear that I should use `this` inside spec methods. 
Also is there a reason for defining `lifecycle` like this? It feels strange to use `this` in all this functional composition. I was thinking if it would be better if spec functions would get props and some `setState` equivalent method as arguments? It will increase API surface but I think it would be more consistent with other methods.