### PR TITLE
add #renameProp, #renameProps and #withReducer examples

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -194,6 +194,16 @@ renameProp(
 
 Renames a single prop.
 
+Example: 
+```js
+const ArticleComponent = ({ articleTitle }) => (
+  <div>{articleTitle}</div>
+);
+const Article = renameProp('title', 'articleTitle')(ArticleComponent);
+
+<Article title="article title" />
+```
+
 ### `renameProps()`
 
 ```js
@@ -203,6 +213,22 @@ renameProps(
 ```
 
 Renames multiple props, using a map of old prop names to new prop names.
+
+Example: 
+```js
+const ArticleComponent = ({ articleTitle, articleBody }) => (
+  <div>
+    <h2>{articleTitle}</h2>
+    <p>{articleBody}</p>
+  </div>
+);
+const Article = renameProps({
+  title: 'articleTitle',
+  body: 'articleBody'
+})(ArticleComponent);
+
+<Article title="article title" body="article body" />
+```
 
 ### `flattenProp()`
 
@@ -337,6 +363,31 @@ withReducer<S, A>(
 Similar to `withState()`, but state updates are applied using a reducer function. A reducer is a function that receives a state and an action, and returns a new state.
 
 Passes two additional props to the base component: a state value, and a dispatch method. The dispatch method sends an action to the reducer, and the new state is applied.
+
+Example:
+```js
+const counterReducer = (state, action) => {
+  switch(action.type) {
+    case: 'INCREMENT':
+      return state + 1;
+    case 'DECREMENT':
+      return state - 1;
+    case: 'RESET':
+      return 0;
+    default:
+      return state;
+  }
+}
+
+const addCounting = compose(
+  withReducer('counter', 'dispatchCounter', counterReducer, 0),
+  withHandlers({
+    increment: ({ dispatchCounter }) => () => dispatchCounter({ type: 'INCREMENT' }),
+    decrement: ({ dispatchCounter }) => () =>  dispatchCounter({ type: 'DECREMENT' }),
+    reset: ({ dispatchCounter }) => () => dispatchCounter({ type: 'RESET' })
+  })
+)
+```
 
 ### `branch()`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -194,14 +194,12 @@ renameProp(
 
 Renames a single prop.
 
-Example: 
-```js
-const ArticleComponent = ({ articleTitle }) => (
-  <div>{articleTitle}</div>
-);
-const Article = renameProp('title', 'articleTitle')(ArticleComponent);
+NOTE: We recommend using `#withProps` and ES6 syntax instead. This method may be deprecated in future releases.
 
-<Article title="article title" />
+```
+renameProp('oldName', 'newName')
+->
+withProps(props => ({newName: props.oldName}))
 ```
 
 ### `renameProps()`
@@ -214,20 +212,11 @@ renameProps(
 
 Renames multiple props, using a map of old prop names to new prop names.
 
-Example: 
-```js
-const ArticleComponent = ({ articleTitle, articleBody }) => (
-  <div>
-    <h2>{articleTitle}</h2>
-    <p>{articleBody}</p>
-  </div>
-);
-const Article = renameProps({
-  title: 'articleTitle',
-  body: 'articleBody'
-})(ArticleComponent);
-
-<Article title="article title" body="article body" />
+NOTE: We recommend using `#withProps` and ES6 syntax instead. This method may be deprecated in future releases.
+```
+renameProps({old1: 'new1', old2: 'new2'})
+->
+withProps(props => ({new1: props.old1, new2: props.old2}))
 ```
 
 ### `flattenProp()`

--- a/docs/API.md
+++ b/docs/API.md
@@ -199,7 +199,7 @@ NOTE: We recommend using `#withProps` and ES6 syntax instead. This method may be
 ```
 renameProp('oldName', 'newName')
 ->
-withProps(props => ({newName: props.oldName}))
+withProps(props => ({ newName: props.oldName }))
 ```
 
 ### `renameProps()`
@@ -214,9 +214,9 @@ Renames multiple props, using a map of old prop names to new prop names.
 
 NOTE: We recommend using `#withProps` and ES6 syntax instead. This method may be deprecated in future releases.
 ```
-renameProps({old1: 'new1', old2: 'new2'})
+renameProps({ old1: 'new1', old2: 'new2' })
 ->
-withProps(props => ({new1: props.old1, new2: props.old2}))
+withProps(props => ({ new1: props.old1, new2: props.old2 }))
 ```
 
 ### `flattenProp()`


### PR DESCRIPTION
@wuct another doc PR. I'm trying to introduce recompose to my team and they get a bit confuse about api description, what do you think about adding those examples?

Also it would be really nice to have some section about writing unit tests for components that uses recompose cause it gets a bit tricky. I'm still trying to wrap my head around how to write them. Should I create an issue to this discuss this further? Or is this something you discussed already?