### PR TITLE
Rethrow subscription errors in componentFromStream

### DIFF
--- a/src/packages/recompose/__tests__/componentFromStream-test.js
+++ b/src/packages/recompose/__tests__/componentFromStream-test.js
@@ -102,3 +102,22 @@ test('completed props stream should throw an exception', () => {
 
   expect(() => wrapper.unmount()).toThrowError(/no elements in sequence/)
 })
+
+// TODO: test that this feeds into componentDidCatch() once upgraded to React 16
+test('throws stream error in render', async () => {
+  const Throws = componentFromStream(props$ =>
+    props$.map(props => {
+      if (props.throw) {
+        throw new Error('thrown from component')
+      } else {
+        return <div>okay</div>
+      }
+    })
+  )
+
+  const wrapper = mount(<Throws />)
+  expect(wrapper.text()).toBe('okay')
+  expect(() => wrapper.setProps({ throw: true })).toThrowError(
+    'thrown from component'
+  )
+})

--- a/src/packages/recompose/__tests__/mapPropsStream-test.js
+++ b/src/packages/recompose/__tests__/mapPropsStream-test.js
@@ -17,3 +17,19 @@ test('mapPropsStream creates a higher-order component from a stream', () => {
   wrapper.setProps({ n: 358 })
   expect(div.text()).toBe('716')
 })
+
+test('mapPropsStream throws errors produced by stream', () => {
+  const Double = mapPropsStream(props$ =>
+    props$.map(({ n }) => {
+      if (n > 0) {
+        return { children: n * 2 }
+      }
+
+      throw new Error('n is too low')
+    })
+  )('div')
+
+  const wrapper = mount(<Double n={1} />)
+  expect(wrapper.text()).toBe('2')
+  expect(() => wrapper.setProps({ n: 0 })).toThrowError('n is too low')
+})

--- a/src/packages/recompose/mapPropsStream.js
+++ b/src/packages/recompose/mapPropsStream.js
@@ -21,6 +21,7 @@ export const mapPropsStreamWithConfig = config => {
           transform(fromESObservable(props$))
         ).subscribe({
           next: childProps => observer.next(factory(childProps)),
+          error: error => observer.error(error),
         })
         return {
           unsubscribe: () => subscription.unsubscribe(),


### PR DESCRIPTION
Fixes #547 

The `renderErrors` property is necessary for [errors emitted by unsubscription](https://github.com/acdlite/recompose/blob/f4745a0ef41d23b00e93ac2d4de7aa9ef0eef053/src/packages/recompose/__tests__/componentFromStream-test.js#L92) to be thrown.

Also includes error handling for `mapPropsStream()`