### PR TITLE
filter packages by the existence of a package.json file

### DIFF
--- a/scripts/getPackageNames.js
+++ b/scripts/getPackageNames.js
@@ -8,11 +8,18 @@ let names
 
 exports.getPackageNames = () => {
   if (!names) {
-    names = fs
-      .readdirSync(exports.PACKAGES_SRC_DIR)
-      .filter(file =>
-        fs.statSync(path.resolve(exports.PACKAGES_SRC_DIR, file)).isDirectory()
-      )
+    names = fs.readdirSync(exports.PACKAGES_SRC_DIR).filter(file => {
+      try {
+        const packageJsonPath = path.resolve(
+          exports.PACKAGES_SRC_DIR,
+          file,
+          'package.json'
+        )
+        return fs.statSync(packageJsonPath).isFile()
+      } catch (error) {
+        return false
+      }
+    })
   }
   return names
 }


### PR DESCRIPTION
Running yarn 1.0 in the recompose repo causes the `installNestedPackageDeps` script to run forever in a loop because it tries to run `yarn` in the `src/packages/rx-recompose` directory, which doesn't have a `package.json` file, which causes the dependencies to be installed in the root project, triggering the already executing postinstall script again and again.

If you'd prefer I can just remove the `src/packages/rx-recompose` directory, but perhaps there's a reason it's still there.