### PR TITLE
toClass extras

### DIFF
--- a/src/packages/recompose/toClass.js
+++ b/src/packages/recompose/toClass.js
@@ -14,7 +14,7 @@ const toClass = (baseComponent, Class = Component) =>
           if (typeof baseComponent === 'string') {
             return React.createElement(baseComponent, this.props)
           }
-          return baseComponent(this.props, this.context)
+          return baseComponent(this.props, this.context, this)
         }
       }
 export default toClass

--- a/src/packages/recompose/toClass.js
+++ b/src/packages/recompose/toClass.js
@@ -2,10 +2,10 @@ import React, { Component } from 'react'
 import getDisplayName from './getDisplayName'
 import isClassComponent from './isClassComponent'
 
-const toClass = baseComponent =>
+const toClass = (baseComponent, Class = Component) =>
   isClassComponent(baseComponent)
     ? baseComponent
-    : class ToClass extends Component {
+    : class ToClass extends Class {
         static displayName = getDisplayName(baseComponent)
         static propTypes = baseComponent.propTypes
         static contextTypes = baseComponent.contextTypes


### PR DESCRIPTION
* allow passing a class to toClass
    allows you to pass PureComponent or any custom class you want to inherit  #from.
* pass 'this' to toClass functional component
    allows functional components to call this.forceUpdate and other
    superclass methods.
    Also allows using 'this' as a basis for memoizing etc.


One usecase is memoizing: I want to have a unique id on some components so I want to use something like:

```js
const wm = new WeakMap();
export default function id(ctx) {
    const id = wm.get(ctx);
    if (id) {
        return id;
    }

    const newId = randomIdStr();
    wm.set(ctx, newId);
    return newId;
}
```

```js
import id from './id';

export default toClass((props, _, ctx) => (
    <form>
         <input id={`${id(ctx)}_foo`} name="foo" />
         <label htmlFor={`${id(ctx)}_foo`}>foo</label>
         <input id={`${id(ctx)}_bar`} name="bar" />
         <label htmlFor={`${id(ctx)}_bar`}>bar</label>
    </form>
));
```

The other is calling a method on the base class for using libraries that provide Mixin based functionality

```js
import SuperClass from 'some-reacty-mixin-lib';

export default toClass((props, _, ctx) => (
    <button onClick={() => ctx.someMethod()} />
), SuperClass);
```
