### PR TITLE
Adding an optional callback argument to the `dispatch` method provided by `withReducer`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -336,7 +336,13 @@ withReducer<S, A>(
 
 Similar to `withState()`, but state updates are applied using a reducer function. A reducer is a function that receives a state and an action, and returns a new state.
 
-Passes two additional props to the base component: a state value, and a dispatch method. The dispatch method sends an action to the reducer, and the new state is applied.
+Passes two additional props to the base component: a state value, and a dispatch method. The dispatch method has the following signature:
+
+```js
+dispatch(action: Object, ?callback: Function): void
+```
+
+It sends an action to the reducer, after which the new state is applied. It also accepts an optional second parameter, a callback function with the new state as its only argument.
 
 ### `branch()`
 

--- a/src/packages/recompose/__tests__/withReducer-test.js
+++ b/src/packages/recompose/__tests__/withReducer-test.js
@@ -67,3 +67,30 @@ test('receives state from reducer when initialState is not provided', () => {
 
   expect(component.lastCall.args[0].counter).toBe(0)
 })
+
+test('calls the given callback with new state after a dispatch call', () => {
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
+  const initialState = { counter: 0 }
+
+  const reducer = (state, action) =>
+    action.type === SET_COUNTER ? { counter: action.payload } : state
+
+  const Counter = compose(
+    withReducer('state', 'dispatch', reducer, initialState),
+    flattenProp('state')
+  )(component)
+
+  mount(<Counter />)
+  const dispatch = sinon.spy(component.firstCall.args[0].dispatch)
+  const callback = sinon.spy()
+
+  dispatch({ type: SET_COUNTER, payload: 11 }, callback)
+  expect(dispatch.calledBefore(callback)).toBe(true)
+  expect(dispatch.calledOnce).toBe(true)
+  expect(callback.calledAfter(dispatch)).toBe(true)
+  expect(callback.calledOnce).toBe(true)
+  expect(callback.getCall(0).args.length).toBe(1)
+  expect(callback.getCall(0).args[0]).toEqual({ counter: 11 })
+})

--- a/src/packages/recompose/withReducer.js
+++ b/src/packages/recompose/withReducer.js
@@ -2,6 +2,8 @@ import { createFactory, Component } from 'react'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 
+const noop = () => {}
+
 const withReducer = (
   stateName,
   dispatchName,
@@ -23,10 +25,13 @@ const withReducer = (
       return reducer(undefined, { type: '@@recompose/INIT' })
     }
 
-    dispatch = action =>
-      this.setState(({ stateValue }) => ({
-        stateValue: reducer(stateValue, action),
-      }))
+    dispatch = (action, callback = noop) =>
+      this.setState(
+        ({ stateValue }) => ({
+          stateValue: reducer(stateValue, action),
+        }),
+        () => callback(this.state.stateValue)
+      )
 
     render() {
       return factory({


### PR DESCRIPTION
I thought of this after looking at `withState`, which provides `stateUpdater` methods that can take in callbacks. My rationale for allowing for an optional callback that receives the new state for the `dispatch` method that `withReducer` provides is that after calculating the new state, you might want to propagate state changes elsewhere. Maybe you need to call a given `onChange` prop or handle some other side effect like that.

We _could_ just execute the reducer with the old state and the action to generate the new state outside of the `dispatch` call, but I find it _really_ clunky to calculate the new state twice - once implicitly as a result of the `dispatch` call and once explicitly by executing the reducer - in order to address these types of scenarios. I am also not a fan of programmatically detecting state changes and handling the associated side effects via `lifecycle` methods.

I chose to use a plain callback over a promise solely because I did not see `recompose` making any real use of promises and I did not want to introduce a new paradigm. I am not attached to this decision.

Thank you for this amazing library! Please let me know what you think of this idea.