### PR TITLE
Context in withContext ;)

### DIFF
--- a/src/packages/recompose/withContext.js
+++ b/src/packages/recompose/withContext.js
@@ -5,7 +5,7 @@ import wrapDisplayName from './wrapDisplayName'
 const withContext = (childContextTypes, getChildContext) => BaseComponent => {
   const factory = createFactory(BaseComponent)
   class WithContext extends Component {
-    getChildContext = () => getChildContext(this.props)
+    getChildContext = () => getChildContext.call(this, this.props)
 
     render() {
       return factory(this.props)


### PR DESCRIPTION
Use `call` to bind the `getChildContext` to the `Component`.

I leave the `this.props` to maintain compatibility. Because we are now (binded), we don't need to pass the `props`.
If we don't use the `this.props` anymore, we could do it like this: `getChildContext = getChildContext.bind(this)` instead.