### PR TITLE
 DOC API compose section recomposing 

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -9,10 +9,14 @@ const EnhancedComponent = hoc(BaseComponent)
 This form makes HOCs (sometimes called **enhancers**) composable:
 
 ```js
-const composedHoc = compose(hoc1, hoc2, hoc3)(BaseComponent)
+// instead of defining usual HOC (ES6 function) definition
+const composedHoc = Component => hoc1(hoc2(hoc3(Component)))
 
-// Same as
-const composedHoc = BaseComponent => hoc1(hoc2(hoc3(BaseComponent)))
+// we can express it shorter
+const composedHoc = compose(hoc1, hoc2, hoc3)
+
+// In both cases we can use this HOC in the same way
+const EnhancedComponent = composedHoc(BaseComponent)
 ```
 
 Most Recompose helpers are **functions that return higher-order components**:

--- a/docs/API.md
+++ b/docs/API.md
@@ -9,7 +9,7 @@ const EnhancedComponent = hoc(BaseComponent)
 This form makes HOCs (sometimes called **enhancers**) composable:
 
 ```js
-const composedHoc = compose(hoc1, hoc2, hoc3)
+const composedHoc = compose(hoc1, hoc2, hoc3)(BaseComponent)
 
 // Same as
 const composedHoc = BaseComponent => hoc1(hoc2(hoc3(BaseComponent)))

--- a/docs/API.md
+++ b/docs/API.md
@@ -9,7 +9,7 @@ const EnhancedComponent = hoc(BaseComponent)
 This form makes HOCs (sometimes called **enhancers**) composable:
 
 ```js
-// instead of defining usual HOC (ES6 function) definition
+// instead of defining HOC as usual (ES6 function)
 const composedHoc = Component => hoc1(hoc2(hoc3(Component)))
 
 // we can express it shorter


### PR DESCRIPTION

grrr, @#$%^  **you're right**  -  I wrongly readed intention - I assumed these are usage examples (I saw many hoc1(hoc2(... used directly on component in export default statement) while they're definitions of HOCs ... prepared for usage/reusing    ..... 

I was watching and not seeing ... that BaseComponent is only parameter definition in ES6 function definition - 1-st one doesn't need this explicitely
I see it **a bit missleading**, now.  In all other code in this section BaseComponent is a real component to be enhanced - this makes some common context while these lines are out of it.

Maybe making it a little more verbose  (updated file) ?
