### PR TITLE
Object Rest/Spread compliance

### DIFF
--- a/src/packages/recompose/nest.js
+++ b/src/packages/recompose/nest.js
@@ -3,7 +3,7 @@ import getDisplayName from './getDisplayName'
 
 const nest = (...Components) => {
   const factories = Components.map(createFactory)
-  const Nest = ({ ...props, children }) =>
+  const Nest = ({ children, ...props }) =>
     factories.reduceRight((child, factory) => factory(props, child), children)
 
   if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
This is an error I ran into while statically analyzing this code. 

In newer versions of `babylon` it will error if the rest param is not the end when desctructuring.

See here: https://github.com/babel/babylon/blob/master/CHANGELOG.md#eyeglasses-spec-compliancy-6