### PR TITLE
Implement withPromiseHandler

### DIFF
--- a/src/packages/recompose/withPromiseHandler.js
+++ b/src/packages/recompose/withPromiseHandler.js
@@ -1,0 +1,59 @@
+import React, {Component} from 'react';
+
+const DEFAULT_PROMISE_NAME = 'response';
+
+const withPromiseHandler = (WrappedComponent, promiseNames = [DEFAULT_PROMISE_NAME]) => {
+  return class extends Component {
+    constructor(props) {
+      super(props);
+
+      // Immediately provide props to child component
+      // Allow careless use of "promised" props
+      // I.E. this.props.response.loading won't throw
+      this.state = promiseNames.reduce((result, name) => {
+        result[name] = {};
+        return result;
+      }, {});
+
+      this.newPromise = this.newPromise.bind(this);
+    }
+
+    updatePromise(name, update) {
+      const promise = this.state[name] || {};
+      this.setState({
+        [name]: {
+          ...promise,
+          ...update
+        }
+      });
+    }
+
+    createSuccessHandler(name) {
+      return data => this.updatePromise(name, { data, loading: false });
+    }
+
+    createErrorHandler(name) {
+      return error => this.updatePromise(name, { error, loading: false });
+    }
+
+    newPromise(promise, name = DEFAULT_PROMISE_NAME) {
+      this.updatePromise(name, {loading: true});
+      promise
+        .then(this.createSuccessHandler(name))
+        .catch(this.createErrorHandler(name));
+      return promise;
+    }
+
+    render() {
+      return (
+        <WrappedComponent
+          {...this.props}
+          {...this.state}
+          newPromise={this.newPromise}
+        />
+      );
+    }
+  };
+}
+
+export default withPromiseHandler;


### PR DESCRIPTION
Hey,

Just want to share an idea here, I think it fits recompose.

Basically, when working with promises in a component I want to preserve React lifecycle or to be more precise be notified that promise is resolved through props update. There is also issue with loading status, there is no easy way to tell if a promise is resolved (usually it ends being saved in the component state).

`withPromiseHandler` provides a method to the wrapped component for registering a promise and in return, it will handle promise. When the promise is resolved, successfully or with error, the result will be saved in the state of the HOC and passed to the wrapped component. 

A bonus is `loading` status which is added to the promise object so that the wrapped component can easily and without any additional state handle that case.

The ultimate thing is that every time promise changes, a wrapped component gets a chance to render that new state automatically.

If you think this fits recompose I can do any needed changes and write tests.

Cheers!