### PR TITLE
Pass blacklist argument to hoist-non-react-statics using hoistStatics

### DIFF
--- a/src/packages/recompose/__tests__/hoistStatics-test.js
+++ b/src/packages/recompose/__tests__/hoistStatics-test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { createFactory } from 'react'
 import { mount } from 'enzyme'
 import sinon from 'sinon'
 import { hoistStatics, mapProps } from '../'
@@ -15,4 +15,18 @@ test('copies non-React static properties from base component to new component', 
 
   mount(<EnhancedComponent n={3} />)
   expect(BaseComponent.firstCall.args[0].n).toBe(15)
+})
+
+test('does not copy blacklisted static properties to new component ', () => {
+  const BaseComponent = sinon.spy(() => null)
+  BaseComponent.foo = () => {}
+  BaseComponent.bar = () => {}
+
+  const EnhancedComponent = hoistStatics(
+    comp => createFactory(comp),
+    { bar: true } // Blacklist
+  )(BaseComponent)
+
+  expect(EnhancedComponent.foo).toBe(BaseComponent.foo)
+  expect(EnhancedComponent.bar).toBe(undefined)
 })

--- a/src/packages/recompose/hoistStatics.js
+++ b/src/packages/recompose/hoistStatics.js
@@ -1,8 +1,8 @@
 import hoistNonReactStatics from 'hoist-non-react-statics'
 
-const hoistStatics = higherOrderComponent => BaseComponent => {
+const hoistStatics = (higherOrderComponent, blacklist) => BaseComponent => {
   const NewComponent = higherOrderComponent(BaseComponent)
-  hoistNonReactStatics(NewComponent, BaseComponent)
+  hoistNonReactStatics(NewComponent, BaseComponent, blacklist)
   return NewComponent
 }
 


### PR DESCRIPTION
[hoist-non-react-statics](https://github.com/mridgway/hoist-non-react-statics) supports an [undocumented argument `blacklist`](https://github.com/mridgway/hoist-non-react-statics/blob/master/src/index.js#L34) in order to blacklist static properties that shall not be copied.

This PR adds that option to `recompose/hoistStatics`.