### PR TITLE
docs: Remove misleading optional annotation

### DIFF
--- a/types/README.md
+++ b/types/README.md
@@ -11,7 +11,7 @@ Example:
 import type { HOC } from 'recompose';
 
 type EnhancedComponentProps = {
-  text?: string,
+  text: string,
 };
 
 const baseComponent = ({ text }) => <div>{text}</div>;


### PR DESCRIPTION
According to the docs, `EnhancedComponentProps` is the type of the props that will be assigned to the generated component.

If this is the case, `text` is never going to be `undefined` or `null` because our HOC is making sure to set it to `string` in any possible case.