### PR TITLE
New lifecycles support

### DIFF
--- a/src/packages/recompose/__tests__/withHandlers-test.js
+++ b/src/packages/recompose/__tests__/withHandlers-test.js
@@ -60,50 +60,6 @@ test('withHandlers passes immutable handlers', () => {
   )
 })
 
-test('withHandlers caches handlers properly', () => {
-  const handlerCreationSpy = sinon.spy()
-  const handlerCallSpy = sinon.spy()
-
-  const enhance = withHandlers({
-    handler: props => {
-      handlerCreationSpy(props)
-      return val => {
-        handlerCallSpy(val)
-      }
-    },
-  })
-
-  const component = sinon.spy(() => null)
-  const Div = enhance(component)
-
-  const wrapper = mount(<Div foo="bar" />)
-  const { handler } = component.firstCall.args[0]
-
-  // Don't create handler until it is called
-  expect(handlerCreationSpy.callCount).toBe(0)
-  expect(handlerCallSpy.callCount).toBe(0)
-
-  handler(1)
-  expect(handlerCreationSpy.callCount).toBe(1)
-  expect(handlerCreationSpy.args[0]).toEqual([{ foo: 'bar' }])
-  expect(handlerCallSpy.callCount).toBe(1)
-  expect(handlerCallSpy.args[0]).toEqual([1])
-
-  // Props haven't changed; should use cached handler
-  handler(2)
-  expect(handlerCreationSpy.callCount).toBe(1)
-  expect(handlerCallSpy.callCount).toBe(2)
-  expect(handlerCallSpy.args[1]).toEqual([2])
-
-  wrapper.setProps({ foo: 'baz' })
-  handler(3)
-  // Props did change; handler should be recreated
-  expect(handlerCreationSpy.callCount).toBe(2)
-  expect(handlerCreationSpy.args[1]).toEqual([{ foo: 'baz' }])
-  expect(handlerCallSpy.callCount).toBe(3)
-  expect(handlerCallSpy.args[2]).toEqual([3])
-})
-
 test('withHandlers warns if handler is not a higher-order function', () => {
   const error = sinon.stub(console, 'error')
 

--- a/src/packages/recompose/__tests__/withPropsOnChange-test.js
+++ b/src/packages/recompose/__tests__/withPropsOnChange-test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { mount } from 'enzyme'
 import sinon from 'sinon'
 import { withPropsOnChange, withState, flattenProp, compose } from '../'

--- a/src/packages/recompose/createSink.js
+++ b/src/packages/recompose/createSink.js
@@ -1,18 +1,22 @@
 import { Component } from 'react'
+import { polyfill } from 'react-lifecycles-compat'
 
-const createSink = callback =>
+const createSink = callback => {
   class Sink extends Component {
-    componentWillMount() {
-      callback(this.props)
-    }
+    state = {}
 
-    componentWillReceiveProps(nextProps) {
+    static getDerivedStateFromProps(nextProps) {
       callback(nextProps)
+      return null
     }
 
     render() {
       return null
     }
   }
+
+  polyfill(Sink)
+  return Sink
+}
 
 export default createSink

--- a/src/packages/recompose/withHandlers.js
+++ b/src/packages/recompose/withHandlers.js
@@ -7,18 +7,10 @@ import mapValues from './utils/mapValues'
 const withHandlers = handlers => BaseComponent => {
   const factory = createFactory(BaseComponent)
   class WithHandlers extends Component {
-    cachedHandlers = {}
-
     handlers = mapValues(
       typeof handlers === 'function' ? handlers(this.props) : handlers,
-      (createHandler, handlerName) => (...args) => {
-        const cachedHandler = this.cachedHandlers[handlerName]
-        if (cachedHandler) {
-          return cachedHandler(...args)
-        }
-
+      createHandler => (...args) => {
         const handler = createHandler(this.props)
-        this.cachedHandlers[handlerName] = handler
 
         if (
           process.env.NODE_ENV !== 'production' &&
@@ -34,10 +26,6 @@ const withHandlers = handlers => BaseComponent => {
         return handler(...args)
       }
     )
-
-    componentWillReceiveProps() {
-      this.cachedHandlers = {}
-    }
 
     render() {
       return factory({

--- a/src/packages/recompose/withPropsOnChange.js
+++ b/src/packages/recompose/withPropsOnChange.js
@@ -17,23 +17,15 @@ const withPropsOnChange = (shouldMapOrKeys, propsMapper) => BaseComponent => {
           )
 
   class WithPropsOnChange extends Component {
-    computedProps = propsMapper(this.props)
-    recalc = {}
-
     state = {
-      recalc: this.recalc,
+      computedProps: propsMapper(this.props),
+      prevProps: this.props,
     }
 
     static getDerivedStateFromProps(nextProps, prevState) {
-      if (!prevState.prevProps) {
-        return {
-          prevProps: nextProps,
-        }
-      }
-
       if (shouldMap(prevState.prevProps, nextProps)) {
         return {
-          recalc: {},
+          computedProps: propsMapper(nextProps),
           prevProps: nextProps,
         }
       }
@@ -42,14 +34,9 @@ const withPropsOnChange = (shouldMapOrKeys, propsMapper) => BaseComponent => {
     }
 
     render() {
-      if (this.recalc !== this.state.recalc) {
-        this.recalc = this.state.recalc
-        this.computedProps = propsMapper(this.props)
-      }
-
       return factory({
         ...this.props,
-        ...this.computedProps,
+        ...this.state.computedProps,
       })
     }
   }

--- a/src/packages/recompose/withPropsOnChange.js
+++ b/src/packages/recompose/withPropsOnChange.js
@@ -5,11 +5,7 @@ import shallowEqual from './shallowEqual'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 
-const withPropsOnChange = (
-  shouldMapOrKeys,
-  propsMapper,
-  memoize = fn => fn
-) => BaseComponent => {
+const withPropsOnChange = (shouldMapOrKeys, propsMapper) => BaseComponent => {
   const factory = createFactory(BaseComponent)
   const shouldMap =
     typeof shouldMapOrKeys === 'function'
@@ -21,8 +17,7 @@ const withPropsOnChange = (
           )
 
   class WithPropsOnChange extends Component {
-    memoizedPropsMapper = memoize(propsMapper)
-    computedProps = this.memoizedPropsMapper(this.props)
+    computedProps = propsMapper(this.props)
     recalc = {}
 
     state = {
@@ -49,7 +44,7 @@ const withPropsOnChange = (
     render() {
       if (this.recalc !== this.state.recalc) {
         this.recalc = this.state.recalc
-        this.computedProps = this.memoizedPropsMapper(this.props)
+        this.computedProps = propsMapper(this.props)
       }
 
       return factory({


### PR DESCRIPTION
In async mode `propsMapper` in `withPropsOnChange` can be called multiple times
it can be avoided using memoize see this commit https://github.com/acdlite/recompose/pull/647/commits/83fc7cadb0af2ef29fd3abbb0a37e634ab5ceddf
but it does not solve some edge cases as memoize will work on all `props` so multiple calls will still be possible. So I think to remove it.