### PR TITLE
 Update rxjsObservableConfig for rxjs 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,9 +80,10 @@
     "rollup-plugin-size-snapshot": "^0.3.0",
     "rollup-plugin-uglify": "^3.0.0",
     "rx": "^4.1.0",
-    "rxjs": "^5.0.0",
+    "rxjs": "^6.0.0",
     "shelljs": "^0.6.0",
     "sinon": "^1.17.1",
+    "symbol-observable": "^1.2.0",
     "webpack": "^2.4.1",
     "xstream": "^5.0.5"
   },

--- a/scripts/jest.setup.js
+++ b/scripts/jest.setup.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
 
+import 'symbol-observable'
 import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 

--- a/src/packages/recompose/__tests__/componentFromStreamWithConfig-test.js
+++ b/src/packages/recompose/__tests__/componentFromStreamWithConfig-test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
 import { Stream as MostStream } from 'most'
 import mostConfig from '../mostObservableConfig'
 import rxjsConfig from '../rxjsObservableConfig'
@@ -20,10 +21,12 @@ test('componentFromStreamWithConfig creates a stream with the correct stream typ
 
   const RXJSComponent = componentFromStreamWithConfig(rxjsConfig)(props$ => {
     expect(props$ instanceof Observable).toBe(true)
-    return props$.map(v =>
-      <div>
-        {String(v)}
-      </div>
+    return props$.pipe(
+      map(v =>
+        <div>
+          {String(v)}
+        </div>
+      )
     )
   })
 

--- a/src/packages/recompose/__tests__/mapPropsStreamWithConfig-test.js
+++ b/src/packages/recompose/__tests__/mapPropsStreamWithConfig-test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { Stream as MostStream } from 'most'
 import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
 import { mapPropsStreamWithConfig } from '../'
 import rxConfig from '../rxjsObservableConfig'
 import mostConfig from '../mostObservableConfig'
@@ -9,7 +10,7 @@ import mostConfig from '../mostObservableConfig'
 // Most of mapPropsStreamConfig's functionality is covered by componentFromStream
 test('mapPropsStreamWithConfig creates a higher-order component from a stream and a observable config', () => {
   const Double = mapPropsStreamWithConfig(rxConfig)(props$ =>
-    props$.map(({ n }) => ({ children: n * 2 }))
+    props$.pipe(map(({ n }) => ({ children: n * 2 })))
   )('div')
   const wrapper = mount(<Double n={112} />)
   const div = wrapper.find('div')
@@ -28,7 +29,7 @@ test('mapPropsStreamWithConfig creates a stream with the correct config', () => 
 
   const RXJSComponent = mapPropsStreamWithConfig(rxConfig)(props$ => {
     expect(props$ instanceof Observable).toBe(true)
-    return props$.map(v => v)
+    return props$.pipe(map(v => v))
   })('div')
 
   mount(<RXJSComponent />)

--- a/src/packages/recompose/__tests__/setObservableConfig-test.js
+++ b/src/packages/recompose/__tests__/setObservableConfig-test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
+import { map } from 'rxjs/operators'
 import rxjs5Config from '../rxjsObservableConfig'
 import rxjs4Config from '../rxjs4ObservableConfig'
 import mostConfig from '../mostObservableConfig'
@@ -22,10 +23,12 @@ const testTransform = transform => {
 test('works with RxJS 5', () => {
   setObservableConfig(rxjs5Config)
   testTransform(props$ =>
-    props$.map(({ n }) =>
-      <div>
-        {n * 2}
-      </div>
+    props$.pipe(
+      map(({ n }) =>
+        <div>
+          {n * 2}
+        </div>
+      )
     )
   )
 })

--- a/src/packages/recompose/rxjsObservableConfig.js
+++ b/src/packages/recompose/rxjsObservableConfig.js
@@ -1,7 +1,7 @@
-import Rx from 'rxjs'
+import { from } from 'rxjs'
 
 const config = {
-  fromESObservable: Rx.Observable.from,
+  fromESObservable: from,
   toESObservable: stream => stream,
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5580,17 +5580,17 @@ rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
-rxjs@^5.0.0:
-  version "5.5.9"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.9.tgz#12a0487794b00f5eb370fec2751bd973a89886fb"
-  dependencies:
-    symbol-observable "1.0.1"
-
 rxjs@^5.0.0-beta.11:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.1.tgz#b62f757f279445d265a18a58fb0a70dc90e91626"
   dependencies:
     symbol-observable "^1.0.1"
+
+rxjs@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.0.0.tgz#d647e029b5854617f994c82fe57a4c6747b352da"
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -6026,13 +6026,13 @@ swap-case@^1.1.0:
     lower-case "^1.1.1"
     upper-case "^1.1.1"
 
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-
 symbol-observable@1.0.4, symbol-observable@^1.0.1, symbol-observable@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
 symbol-tree@^3.2.2:
   version "3.2.2"
@@ -6189,6 +6189,10 @@ trim-right@^1.0.1:
 tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
+
+tslib@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Need some discussion before merging:

1. There were `rxjs4ObservableConfig.js` and `rxjsObservableConfig.js` (for rxjs 5) before. This PR upgrade `rxjsObservableConfig.js` directly to adopt rxjs 6, but it's a breaking change. We might want to create separate files for both rxjs 5 and rxjs 6.

2. Rxjs used to polyfill `Symbol.observable`, but it has been removed since https://github.com/ReactiveX/rxjs/pull/3387. We might need to add a notice about polyfill `Symbol.observable` to the doc.

