### PR TITLE
yarn --ignore-engines on travis CI (which runs node 10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "node"
+install: "yarn install --ignore-engines"
 before_script: "npm install -g codeclimate-test-reporter"
 script:
   - yarn run lint


### PR DESCRIPTION
Fixes issue with webpack 2.7.0 -> upath <1.0.5 dependency, which incorrectly specifies compatibility with node <= 9

Issue described here: https://github.com/anodynos/upath/pull/15 and fixed here https://github.com/anodynos/upath/commit/8c5f4e10376ed1cd4553d9432297d39a34410c69#diff-b9cfc7f2cdf78a7f4b91a753d10865a2 (released as 1.0.5)

Kind of hacky but this unblocks CI until travis's yarn stops resolving the older version. It's 1.0.5 on my local so I'm not 100% sure what travis's problem is.