### PR TITLE
Refactor deprecated lifecycle hooks in `componentFromStream`

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "lib/packages/recompose/dist/Recompose.umd.js": {
-    "bundled": 85035,
-    "minified": 31377,
-    "gzipped": 10006
+    "bundled": 84914,
+    "minified": 31331,
+    "gzipped": 10001
   },
   "lib/packages/recompose/dist/Recompose.min.js": {
-    "bundled": 81529,
-    "minified": 30125,
-    "gzipped": 9618
+    "bundled": 81408,
+    "minified": 30079,
+    "gzipped": 9615
   },
   "lib/packages/recompose/dist/Recompose.esm.js": {
-    "bundled": 31436,
-    "minified": 15712,
-    "gzipped": 3522,
+    "bundled": 31315,
+    "minified": 15666,
+    "gzipped": 3519,
     "treeshaked": {
       "rollup": 601,
       "webpack": 1863

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "npm": "3.x"
   },
   "dependencies": {
+    "create-subscription": "^16.4.0",
     "enzyme-adapter-react-16": "^1.1.1"
   }
 }

--- a/src/packages/recompose/componentFromStream.js
+++ b/src/packages/recompose/componentFromStream.js
@@ -29,23 +29,22 @@ export const componentFromStreamWithConfig = config => propsToVdom =>
     // Stream of vdom
     vdom$ = config.toESObservable(propsToVdom(this.props$))
 
-    componentWillMount() {
+    componentDidMount() {
       // Subscribe to child prop changes so we know when to re-render
       this.subscription = this.vdom$.subscribe({
         next: vdom => {
-          this.setState({ vdom })
+          if (this.state.vdom !== vdom) {
+            this.setState({ vdom })
+          }
         },
       })
       this.propsEmitter.emit(this.props)
     }
 
-    componentWillReceiveProps(nextProps) {
-      // Receive new props from the owner
-      this.propsEmitter.emit(nextProps)
-    }
-
-    shouldComponentUpdate(nextProps, nextState) {
-      return nextState.vdom !== this.state.vdom
+    componentDidUpdate(prevProps) {
+      if (this.props !== prevProps) {
+        this.propsEmitter.emit(this.props)
+      }
     }
 
     componentWillUnmount() {

--- a/src/packages/recompose/componentFromStream.js
+++ b/src/packages/recompose/componentFromStream.js
@@ -1,12 +1,46 @@
-import { Component } from 'react'
+import React, { Component } from 'react'
+import { createSubscription } from 'create-subscription'
 import { createChangeEmitter } from 'change-emitter'
 import $$observable from 'symbol-observable'
 import { config as globalConfig } from './setObservableConfig'
 
+class SimpleBehaviorSubject {
+  currentValue = null
+
+  constructor(observable) {
+    this.observable = observable
+  }
+
+  getCurrentValue() {
+    return this.currentValue
+  }
+
+  subscribe(callback) {
+    const subscription = this.observable.subscribe({
+      next: value => {
+        this.currentValue = value
+        callback(value)
+      },
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }
+}
+
+const Subscription = createSubscription({
+  subscribe(simpleSubject, callback) {
+    return simpleSubject.subscribe(callback)
+  },
+
+  getCurrentValue(simpleSubject) {
+    return simpleSubject.getCurrentValue()
+  },
+})
+
 export const componentFromStreamWithConfig = config => propsToVdom =>
   class ComponentFromStream extends Component {
-    state = { vdom: null }
-
     propsEmitter = createChangeEmitter()
 
     // Stream of props
@@ -29,17 +63,24 @@ export const componentFromStreamWithConfig = config => propsToVdom =>
     // Stream of vdom
     vdom$ = config.toESObservable(propsToVdom(this.props$))
 
-    componentDidMount() {
-      // Subscribe to child prop changes so we know when to re-render
-      this.subscription = this.vdom$.subscribe({
-        next: vdom => {
-          if (this.state.vdom !== vdom) {
-            this.setState({ vdom })
-          }
-        },
-      })
-      this.propsEmitter.emit(this.props)
+    constructor(props) {
+      super(props)
+
+      this.subscription = new SimpleBehaviorSubject(this.vdom$)
+      this.propsEmitter.emit(props)
     }
+
+    // componentDidMount() {
+    //   // Subscribe to child prop changes so we know when to re-render
+    //   this.subscription = this.vdom$.subscribe({
+    //     next: vdom => {
+    //       if (this.state.vdom !== vdom) {
+    //         this.setState({ vdom })
+    //       }
+    //     },
+    //   })
+    //   this.propsEmitter.emit(this.props)
+    // }
 
     componentDidUpdate(prevProps) {
       if (this.props !== prevProps) {
@@ -49,14 +90,17 @@ export const componentFromStreamWithConfig = config => propsToVdom =>
 
     componentWillUnmount() {
       // Call without arguments to complete stream
-      this.propsEmitter.emit()
-
+      // this.propsEmitter.emit()
       // Clean-up subscription before un-mounting
-      this.subscription.unsubscribe()
+      // this.subscription.unsubscribe()
     }
 
     render() {
-      return this.state.vdom
+      return (
+        <Subscription source={this.subscription}>
+          {vdom => vdom}
+        </Subscription>
+      )
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1690,6 +1690,12 @@ create-react-class@^15.5.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-subscription@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/create-subscription/-/create-subscription-16.4.0.tgz#0202bdb5603aa08867a8907bd78fcd262f7407ab"
+  dependencies:
+    fbjs "^0.8.16"
+
 cross-env@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-4.0.0.tgz#16083862d08275a4628b0b243b121bedaa55dd80"


### PR DESCRIPTION
The usage of `componentWillMount` and `componentWillReceiveProps` is deprecated as of React v16. This PR moves the event emissionnn upon the component being rendered with new props into other lifecycle hooks.

Even though the tests are still running fine here, there may be some performance hitch that have went by me, so feel free to comment!