### PR TITLE
Fix withPropsOnChange shouldMap consistency

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,17 +1,17 @@
 {
   "lib/packages/recompose/dist/Recompose.umd.js": {
-    "bundled": 85972,
-    "minified": 31684,
-    "gzipped": 10057
+    "bundled": 86014,
+    "minified": 31693,
+    "gzipped": 10059
   },
   "lib/packages/recompose/dist/Recompose.min.js": {
-    "bundled": 82350,
-    "minified": 30401,
-    "gzipped": 9666
+    "bundled": 82392,
+    "minified": 30410,
+    "gzipped": 9667
   },
   "lib/packages/recompose/dist/Recompose.esm.js": {
-    "bundled": 32336,
-    "minified": 16109,
+    "bundled": 32374,
+    "minified": 16118,
     "gzipped": 3577,
     "treeshaked": {
       "rollup": 601,

--- a/src/packages/recompose/__tests__/withPropsOnChange-test.js
+++ b/src/packages/recompose/__tests__/withPropsOnChange-test.js
@@ -1,7 +1,13 @@
 import * as React from 'react'
 import { mount } from 'enzyme'
 import sinon from 'sinon'
-import { withPropsOnChange, withState, flattenProp, compose } from '../'
+import {
+  withPropsOnChange,
+  withState,
+  withStateHandlers,
+  flattenProp,
+  compose,
+} from '../'
 
 test('withPropsOnChange maps subset of owner props to child props', () => {
   const component = sinon.spy(() => null)
@@ -42,4 +48,73 @@ test('withPropsOnChange maps subset of owner props to child props', () => {
   expect(component.lastCall.args[0].c).toBe('baz')
   expect(component.calledThrice).toBe(true)
   expect(mapSpy.callCount).toBe(2)
+})
+
+test('withPropsOnChange maps subset of owner props to child props with custom predicate', () => {
+  const component = sinon.spy(() => null)
+  component.displayName = 'component'
+
+  const mapSpy = sinon.spy()
+  const shouldMapSpy = sinon.spy()
+  const PageContainer = compose(
+    withStateHandlers(
+      { result: { hasError: false, loading: true, error: null } },
+      {
+        updateResult: ({ result }) => payload => ({
+          result: { ...result, ...payload },
+        }),
+      }
+    ),
+    withPropsOnChange(
+      ({ result }, { result: nextResult }) => {
+        shouldMapSpy(result, nextResult)
+        return !result.hasError && nextResult.hasError
+      },
+      ({ result: { hasError, error } }) => {
+        mapSpy()
+
+        if (hasError) {
+          return {
+            errorEverHappened: true,
+            lastError: error,
+          }
+        }
+
+        return {
+          errorEverHappened: false,
+        }
+      }
+    )
+  )(component)
+
+  expect(PageContainer.displayName).toBe(
+    'withStateHandlers(withPropsOnChange(component))'
+  )
+
+  mount(<PageContainer />)
+  const { updateResult } = component.firstCall.args[0]
+  expect(component.lastCall.args[0].errorEverHappened).toBe(false)
+  expect(component.lastCall.args[0].lastError).toBeUndefined()
+  expect(component.calledOnce).toBe(true)
+  expect(mapSpy.callCount).toBe(1)
+  expect(shouldMapSpy.callCount).toBe(1)
+
+  updateResult({ loading: false, hasError: true, error: '1' })
+  expect(component.lastCall.args[0].errorEverHappened).toBe(true)
+  expect(component.lastCall.args[0].lastError).toBe('1')
+  expect(component.calledTwice).toBe(true)
+  expect(mapSpy.callCount).toBe(2)
+
+  // Does not re-map for false map result
+  updateResult({ loading: true, hasError: false, error: null })
+  expect(component.lastCall.args[0].errorEverHappened).toBe(true)
+  expect(component.lastCall.args[0].lastError).toBe('1')
+  expect(component.calledThrice).toBe(true)
+  expect(mapSpy.callCount).toBe(2)
+
+  updateResult({ loading: false, hasError: true, error: '2' })
+  expect(component.lastCall.args[0].errorEverHappened).toBe(true)
+  expect(component.lastCall.args[0].lastError).toBe('2')
+  expect(component.callCount).toBe(4)
+  expect(mapSpy.callCount).toBe(3)
 })

--- a/src/packages/recompose/withPropsOnChange.js
+++ b/src/packages/recompose/withPropsOnChange.js
@@ -30,7 +30,9 @@ const withPropsOnChange = (shouldMapOrKeys, propsMapper) => BaseComponent => {
         }
       }
 
-      return null
+      return {
+        prevProps: nextProps,
+      }
     }
 
     render() {


### PR DESCRIPTION
In continuation to the discussion in https://github.com/acdlite/recompose/issues/666.
Saving prevProps returns the HOC to it's original behavior before the lifecycle updates.
Added test case that fails with the current implementation and passes with the fix.