### PR TITLE
Include license in published packages

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Andrew Clark
+Copyright (c) 2015-2018 Andrew Clark
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -121,6 +121,9 @@ try {
     JSON.stringify(packageConfig, null, 2)
   )
 
+  log('Copying license...')
+  cp('-f', 'LICENSE.md', outDir)
+
   log(`Building ${packageName}...`)
   const runRollup = () => `yarn build:${packageName}`
   if (exec(runRollup()).code !== 0) {


### PR DESCRIPTION
Also, update the license dates.

For legal purposes, it's often preferable to have the actual license file. See also e.g. https://github.com/lerna/lerna/pull/1465.