### PR TITLE
Remove useless optimisation

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "lib/packages/recompose/dist/Recompose.umd.js": {
-    "bundled": 46995,
-    "minified": 16584,
-    "gzipped": 4651
+    "bundled": 46555,
+    "minified": 16485,
+    "gzipped": 4623
   },
   "lib/packages/recompose/dist/Recompose.min.js": {
-    "bundled": 43433,
-    "minified": 15304,
-    "gzipped": 4220
+    "bundled": 42993,
+    "minified": 15205,
+    "gzipped": 4193
   },
   "lib/packages/recompose/dist/Recompose.esm.js": {
-    "bundled": 31320,
-    "minified": 14839,
-    "gzipped": 3451,
+    "bundled": 30894,
+    "minified": 14729,
+    "gzipped": 3417,
     "treeshaked": {
       "rollup": {
         "code": 340,

--- a/src/packages/recompose/withStateHandlers.js
+++ b/src/packages/recompose/withStateHandlers.js
@@ -1,7 +1,6 @@
 import { createFactory, Component } from 'react'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
-import shallowEqual from './shallowEqual'
 import mapValues from './utils/mapValues'
 
 const withStateHandlers = (initialState, stateUpdaters) => BaseComponent => {
@@ -26,14 +25,6 @@ const withStateHandlers = (initialState, stateUpdaters) => BaseComponent => {
         )
       }
     )
-
-    shouldComponentUpdate(nextProps, nextState) {
-      const propsChanged = nextProps !== this.props
-      // the idea is to skip render if stateUpdater handler return undefined
-      // this allows to create no state update handlers with access to state and props
-      const stateChanged = !shallowEqual(nextState, this.state)
-      return propsChanged || stateChanged
-    }
 
     render() {
       return factory({


### PR DESCRIPTION
Removed optimisation is useless in React 16. The only intent for it was to not update if null was returned in handler. 
But returning same value didn't caused update too, this is not same as React setState works.
This is possibly a breaking change.