### PR TITLE
Enable flow strict

### DIFF
--- a/src/packages/recompose/index.js.flow
+++ b/src/packages/recompose/index.js.flow
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-/* @flow */
+/* @flow strict */
 
 /**
  * 1) Types give additional constraint on a language, recompose was written on the untyped language


### PR DESCRIPTION
Allows downstream dependencies to enable the flow nonstrict-import rule