### PR TITLE
Add version to allow yarn add from GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "recompose-build",
   "private": true,
   "author": "Andrew Clark <acdlite@me.com>",
+  "version": "0.30.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/acdlite/recompose.git"


### PR DESCRIPTION
I am trying to install the master from GitHub, but yarn complains about a missing version