### PR TITLE
added $Exact to spread withStateHandlers properly

### DIFF
--- a/src/packages/recompose/index.js.flow
+++ b/src/packages/recompose/index.js.flow
@@ -102,10 +102,10 @@ declare export function withStateHandlers<
   {
     ...$Exact<Enhanced>,
     ...$Exact<State>,
-    ...$ObjMap<
+    ...$Exact<$ObjMap<
       $ObjMap<StateHandlers, ExtractStateHandlersCodomain>,
       ExtractToVoid
-    >,
+    >>,
   },
   Enhanced
 >


### PR DESCRIPTION
To allow spread working properly, all it items should be $Exact types. Maybe previously it wasn't working this way, but in current version of flow, it's required.