### PR TITLE
Change `withContext` and `getContext` to use new context API

### DIFF
--- a/src/packages/recompose/contextManager.js
+++ b/src/packages/recompose/contextManager.js
@@ -1,0 +1,13 @@
+import { createContext } from 'react'
+
+const contextCache = {}
+
+export const getContextPair = contextName => {
+  if (contextCache[contextName]) {
+    return contextCache[contextName]
+  }
+  const contextPair = createContext()
+  contextPair.contextName = contextName
+  contextCache[contextName] = contextPair
+  return contextPair
+}

--- a/src/packages/recompose/getContext.js
+++ b/src/packages/recompose/getContext.js
@@ -1,16 +1,30 @@
-import { createFactory } from 'react'
+import React from 'react'
+import compose from './compose'
+import { getContextPair } from './contextManager'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
+import mapValues from './utils/mapValues'
 
-const getContext = contextTypes => BaseComponent => {
-  const factory = createFactory(BaseComponent)
-  const GetContext = (ownerProps, context) =>
-    factory({
-      ...ownerProps,
-      ...context,
-    })
+const consumerHoc = (Consumer, contextName) => BaseComponent => props => (
+  <Consumer>
+    {value => <BaseComponent {...{ ...props, [contextName]: value }} />}
+  </Consumer>
+)
 
-  GetContext.contextTypes = contextTypes
+const getContext = childContextTypes => BaseComponent => {
+  const contextNames = Object.keys(childContextTypes)
+  const contextConsumers = mapValues(
+    childContextTypes,
+    (v, k) => getContextPair(k).Consumer
+  )
+
+  const enhancer = compose(
+    ...contextNames.map(contextName =>
+      consumerHoc(contextConsumers[contextName], contextName)
+    )
+  )
+
+  const GetContext = enhancer(BaseComponent)
 
   if (process.env.NODE_ENV !== 'production') {
     return setDisplayName(wrapDisplayName(BaseComponent, 'getContext'))(

--- a/src/packages/recompose/withContext.js
+++ b/src/packages/recompose/withContext.js
@@ -1,18 +1,29 @@
-import { createFactory, Component } from 'react'
+import React from 'react'
+import { getContextPair } from './contextManager'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
+import mapValues from './utils/mapValues'
 
 const withContext = (childContextTypes, getChildContext) => BaseComponent => {
-  const factory = createFactory(BaseComponent)
-  class WithContext extends Component {
-    getChildContext = () => getChildContext(this.props)
+  const contextNames = Object.keys(childContextTypes)
+  const contextProviders = mapValues(
+    childContextTypes,
+    (v, k) => getContextPair(k).Provider
+  )
+  const WithContext = props => {
+    const contextValues = getChildContext(props)
+    const element = contextNames.reduce(
+      (acc, contextName) =>
+        React.createElement(
+          contextProviders[contextName],
+          { value: contextValues[contextName] },
+          acc
+        ),
+      React.createElement(BaseComponent, props)
+    )
 
-    render() {
-      return factory(this.props)
-    }
+    return element
   }
-
-  WithContext.childContextTypes = childContextTypes
 
   if (process.env.NODE_ENV !== 'production') {
     return setDisplayName(wrapDisplayName(BaseComponent, 'withContext'))(


### PR DESCRIPTION
related https://github.com/acdlite/recompose/issues/609

## Abstract

The new context API has an ability to bypass `PureComponent` and `shouldComponentUpdate` check that prevents component updating from context change, opposes to the legacy API that totally ignores context change if parent component haven't updated.

As far as I'm aware, this isn't breaking change, except some of those apps running by relying on the old API quirk. But overall this should improve the way the app behaves on context change.

The new context API rely on React 16.3 which is already a dependency of recompose package.

Here's a demo on how the new API behave compare to the legacy one https://codesandbox.io/s/1o5y0r419j

## The problem I found during build:

- I couldn't test locally because of jest kept throwing an error:
  ```
  SecurityError: localStorage is not available for opaque origins
  ```
  on every test since I first clone this repo. And I don't know how to fix this error.
- The test on 2 API might have been broken because the new context API require you to include its Provider/Consumer components which change the render tree.
- `yarn test` in `prepush` comment also has an error
  ```
  ERROR: [Errno 2] No such file or directory: 'test'
  ```