### PR TITLE
feat(renderNothing): export Nothing component #776

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -462,6 +462,13 @@ const Post = enhance(({ title, author, content }) =>
 )
 ```
 
+It's also possible get the hoc class Nothing used :
+```
+import { renderNothing } from 'recompose';
+
+const { Nothing } = renderNothing;
+```
+
 ### `shouldUpdate()`
 
 ```js

--- a/src/packages/recompose/renderNothing.js
+++ b/src/packages/recompose/renderNothing.js
@@ -1,6 +1,6 @@
 import { Component } from 'react'
 
-class Nothing extends Component {
+export class Nothing extends Component {
   render() {
     return null
   }


### PR DESCRIPTION
Simply export Nothing to let developers use it when they have to manipulate the render tree :) Ref to #776 