### PR TITLE
Inject props on lifecycle hooks

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "lib/packages/recompose/dist/Recompose.umd.js": {
-    "bundled": 46425,
-    "minified": 16484,
-    "gzipped": 4625
+    "bundled": 47601,
+    "minified": 17168,
+    "gzipped": 4791
   },
   "lib/packages/recompose/dist/Recompose.min.js": {
-    "bundled": 42863,
-    "minified": 15204,
-    "gzipped": 4194
+    "bundled": 43785,
+    "minified": 15740,
+    "gzipped": 4302
   },
   "lib/packages/recompose/dist/Recompose.esm.js": {
-    "bundled": 32428,
-    "minified": 15083,
-    "gzipped": 3550,
+    "bundled": 33552,
+    "minified": 15830,
+    "gzipped": 3750,
     "treeshaked": {
       "rollup": {
         "code": 310,

--- a/docs/API.md
+++ b/docs/API.md
@@ -196,6 +196,25 @@ renameProp(
 
 Renames a single prop.
 
+Example:
+
+```js
+const enhance = compose(
+  withProps({ 'loadingDataFromApi': true, 'posts': [] }),
+  renameProp('loadingDataFromApi', 'isLoading'),
+  renameProp('posts', 'items'),
+);
+
+const Posts = enhance(({ isLoading, items }) => (
+  <div>
+    <div>Loading: { isLoading ? 'yes' : 'no'}</div>
+    <ul>
+      {isLoading && items.map(({ id, title }) => (<li key={id}>{title}</li>))}
+    </ul>
+  </div>
+));
+```
+
 ### `renameProps()`
 
 ```js
@@ -205,6 +224,24 @@ renameProps(
 ```
 
 Renames multiple props, using a map of old prop names to new prop names.
+
+Example:
+
+```js
+const enhance = compose(
+  withProps({ 'loadingDataFromApi': true, 'posts': [] }),
+  renameProps({ 'loadingDataFromApi': 'isLoading', 'posts': 'items' }),
+);
+
+const Posts = enhance(({ isLoading, items }) => (
+  <div>
+    <div>Loading: { isLoading ? 'yes' : 'no'}</div>
+    <ul>
+      {isLoading && items.map(({ id, title }) => (<li key={id}>{title}</li>))}
+    </ul>
+  </div>
+));
+```
 
 ### `flattenProp()`
 
@@ -538,7 +575,10 @@ lifecycle(
 
 A higher-order component version of [`React.Component()`](https://facebook.github.io/react/docs/react-api.html#react.component). It supports the entire `Component` API, except the `render()` method, which is implemented by default (and overridden if specified; an error will be logged to the console). You should use this helper as an escape hatch, in case you need to access component lifecycle methods.
 
-Any state changes made in a lifecycle method, by using `setState`, will be propagated to the wrapped component as props.
+Each hook lifecycle will receive as an input a high-order function with the current props.
+The hooks will not longer have access to the `this` reference of the generated high-order component, encouraging a more functional style for your components.
+
+If you need to use `setState` here, please use [`withState()`](#withstate).
 
 Example:
 ```js
@@ -547,9 +587,9 @@ const PostsList = ({ posts }) => (
 )
 
 const PostsListWithData = lifecycle({
-  componentDidMount() {
-    fetchPosts().then(posts => {
-      this.setState({ posts });
+  componentDidMount: props => () => {
+    fetchPosts(props.id).then(posts => {
+      // Do something with the posts
     })
   }
 })(PostsList);

--- a/src/packages/recompose/__tests__/lifecycle-test.js
+++ b/src/packages/recompose/__tests__/lifecycle-test.js
@@ -2,16 +2,39 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { lifecycle } from '../'
 
+const ExampleComponent = ({ title }) => <h1>{title}</h1>
+
 test('lifecycle is a higher-order component version of React.Component', () => {
   const enhance = lifecycle({
-    componentWillMount() {
-      this.setState({ 'data-bar': 'baz' })
+    componentWillMount: () => () => {},
+  })
+  const TestComponent = enhance(ExampleComponent)
+  const mountedComponent = mount(<TestComponent title="Awesome title" />)
+  expect(mountedComponent.props().title).toBe('Awesome title')
+})
+
+test('lifecycle hooks should inject props', done => {
+  const enhance = lifecycle({
+    componentDidMount: props => () => {
+      expect(props.title).toBe('awesome prop')
+      done()
     },
   })
-  const Div = enhance('div')
-  expect(Div.displayName).toBe('lifecycle(div)')
 
-  const div = mount(<Div data-foo="bar" />).find('div')
-  expect(div.prop('data-foo')).toBe('bar')
-  expect(div.prop('data-bar')).toBe('baz')
+  const TestComponent = enhance(ExampleComponent)
+  mount(<TestComponent title="awesome prop" />)
+})
+
+test('lifecycle hook with props will receive them correctly', done => {
+  const enhance = lifecycle({
+    componentWillReceiveProps: props => nextProps => {
+      expect(props.title).toBe('awesome prop')
+      expect(nextProps.title).toBe('updated title')
+      done()
+    },
+  })
+
+  const TestComponent = enhance(ExampleComponent)
+  const component = mount(<TestComponent title="awesome prop" />)
+  component.setProps({ title: 'updated title' })
 })

--- a/src/packages/recompose/lifecycle.js
+++ b/src/packages/recompose/lifecycle.js
@@ -3,8 +3,34 @@ import { createFactory, Component } from 'react'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 
+const ActualLifecycles = [
+  'componentWillMount',
+  'componentDidMount',
+  'componentWillReceiveProps',
+  'shouldComponentUpdate',
+  'componentWillUpdate',
+  'componentDidUpdate',
+  'componentWillUnmount',
+  'componentDidCatch',
+  'getSnapshotBeforeUpdate',
+  'componentDidCatch',
+  'getDerivedStateFromProps',
+]
+
+const validateLifecycles = spec => {
+  const invalidEntries = Object.keys(spec).filter(
+    lc => !ActualLifecycles.includes(lc)
+  )
+  return { validLifecycles: invalidEntries.length === 0, invalidEntries }
+}
+
 const lifecycle = spec => BaseComponent => {
   const factory = createFactory(BaseComponent)
+  const { validLifecycles, invalidEntries } = validateLifecycles(spec)
+
+  if (process.env.NODE_ENV !== 'production' && !validLifecycles) {
+    console.error(`Invalid lifecycle entries: ${invalidEntries.join(',')}.`)
+  }
 
   if (process.env.NODE_ENV !== 'production' && spec.hasOwnProperty('render')) {
     console.error(
@@ -22,7 +48,12 @@ const lifecycle = spec => BaseComponent => {
     }
   }
 
-  Object.keys(spec).forEach(hook => (Lifecycle.prototype[hook] = spec[hook]))
+  Object.keys(spec).forEach(hook => {
+    const currentLifecycle = spec[hook]
+    Lifecycle.prototype[hook] = function hookFn(...hookArgs) {
+      return currentLifecycle(this.props).apply(this, hookArgs)
+    }
+  })
 
   if (process.env.NODE_ENV !== 'production') {
     return setDisplayName(wrapDisplayName(BaseComponent, 'lifecycle'))(


### PR DESCRIPTION
The first time i used the recompose `lifecycle` i needed to use the component props inside of my hooks, so i had no idea what to do because i was expecting to receive those props but it was not the case. 
After some google research i find out that i should use `this.props` but somehow it felt unnatural to me due i was using recompose to approach my components in a more *functional way*.

I saw a few issues about it like [#682](https://github.com/acdlite/recompose/issues/682) and i felt like i could work on this. 

You can say this is my first attempt to OS contribution so i am pretty sure i will have a lot to improve. I ask a bit of your patience and help, i will do my best in order to get this done.

**Notes:**
- New unit tests added in order to cover this feature.
- Added validation for checking that the lifecycles used are valid. This one is motivated to the fact that you can have typo errors and they can lead on very tricky bugs to find.
- Documentation updated.

Please excuse my english but it is not my main language, i am working to improve it.