### PR TITLE
React.createFactory is deprecated

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "lib/packages/recompose/dist/Recompose.umd.js": {
-    "bundled": 46425,
-    "minified": 16484,
-    "gzipped": 4625
+    "bundled": 46431,
+    "minified": 16297,
+    "gzipped": 4640
   },
   "lib/packages/recompose/dist/Recompose.min.js": {
-    "bundled": 42863,
-    "minified": 15204,
-    "gzipped": 4194
+    "bundled": 42869,
+    "minified": 15017,
+    "gzipped": 4198
   },
   "lib/packages/recompose/dist/Recompose.esm.js": {
-    "bundled": 32428,
-    "minified": 15083,
-    "gzipped": 3550,
+    "bundled": 32509,
+    "minified": 15130,
+    "gzipped": 3560,
     "treeshaked": {
       "rollup": {
         "code": 310,

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Путин Убийца!!!
+
+
 ## A Note from the Author (acdlite, Oct 25 2018):
 
 Hi! I created Recompose about three years ago. About a year after that, I joined the React team. Today, we announced a proposal for [*Hooks*](https://reactjs.org/hooks). Hooks solves all the problems I attempted to address with Recompose three years ago, and more on top of that. I will be discontinuing active maintenance of this package (excluding perhaps bugfixes or patches for compatibility with future React releases), and recommending that people use Hooks instead. **Your existing code with Recompose will still work**, just don't expect any new features. Thank you so, so much to [@wuct](https://github.com/wuct) and [@istarkov](https://github.com/istarkov) for their heroic work maintaining Recompose over the last few years.

--- a/src/packages/recompose/__tests__/hoistStatics-test.js
+++ b/src/packages/recompose/__tests__/hoistStatics-test.js
@@ -1,6 +1,7 @@
-import React, { createFactory } from 'react'
+import React from 'react'
 import { mount } from 'enzyme'
 import sinon from 'sinon'
+import createFactory from '../utils/createFactory'
 import { hoistStatics, mapProps } from '../'
 
 test('copies non-React static properties from base component to new component', () => {

--- a/src/packages/recompose/branch.js
+++ b/src/packages/recompose/branch.js
@@ -1,4 +1,4 @@
-import { createFactory } from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 

--- a/src/packages/recompose/defaultProps.js
+++ b/src/packages/recompose/defaultProps.js
@@ -1,4 +1,4 @@
-import { createFactory } from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 

--- a/src/packages/recompose/flattenProp.js
+++ b/src/packages/recompose/flattenProp.js
@@ -1,4 +1,4 @@
-import { createFactory } from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 

--- a/src/packages/recompose/fromRenderProps.js
+++ b/src/packages/recompose/fromRenderProps.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 
@@ -7,8 +7,8 @@ const fromRenderProps = (
   propsMapper,
   renderPropName = 'children'
 ) => BaseComponent => {
-  const baseFactory = React.createFactory(BaseComponent)
-  const renderPropsFactory = React.createFactory(RenderPropsComponent)
+  const baseFactory = createFactory(BaseComponent)
+  const renderPropsFactory = createFactory(RenderPropsComponent)
 
   const FromRenderProps = ownerProps =>
     renderPropsFactory({

--- a/src/packages/recompose/getContext.js
+++ b/src/packages/recompose/getContext.js
@@ -1,4 +1,4 @@
-import { createFactory } from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 

--- a/src/packages/recompose/lifecycle.js
+++ b/src/packages/recompose/lifecycle.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
-import { createFactory, Component } from 'react'
+import { Component } from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 

--- a/src/packages/recompose/mapProps.js
+++ b/src/packages/recompose/mapProps.js
@@ -1,4 +1,4 @@
-import { createFactory } from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 

--- a/src/packages/recompose/mapPropsStream.js
+++ b/src/packages/recompose/mapPropsStream.js
@@ -1,5 +1,5 @@
-import { createFactory } from 'react'
 import $$observable from 'symbol-observable'
+import createFactory from './utils/createFactory'
 import { componentFromStreamWithConfig } from './componentFromStream'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'

--- a/src/packages/recompose/nest.js
+++ b/src/packages/recompose/nest.js
@@ -1,4 +1,4 @@
-import { createFactory } from 'react'
+import createFactory from './utils/createFactory'
 import getDisplayName from './getDisplayName'
 
 const nest = (...Components) => {

--- a/src/packages/recompose/renderComponent.js
+++ b/src/packages/recompose/renderComponent.js
@@ -1,4 +1,4 @@
-import { createFactory } from 'react'
+import createFactory from './utils/createFactory'
 import wrapDisplayName from './wrapDisplayName'
 
 const renderComponent = Component => _ => {

--- a/src/packages/recompose/shouldUpdate.js
+++ b/src/packages/recompose/shouldUpdate.js
@@ -1,4 +1,5 @@
-import { createFactory, Component } from 'react'
+import { Component } from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 

--- a/src/packages/recompose/utils/createFactory.js
+++ b/src/packages/recompose/utils/createFactory.js
@@ -1,0 +1,5 @@
+import { createElement } from 'react'
+
+const createFactory = Type => createElement.bind(null, Type)
+
+export default createFactory

--- a/src/packages/recompose/withContext.js
+++ b/src/packages/recompose/withContext.js
@@ -1,4 +1,5 @@
-import { createFactory, Component } from 'react'
+import { Component } from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 

--- a/src/packages/recompose/withHandlers.js
+++ b/src/packages/recompose/withHandlers.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
-import { createFactory, Component } from 'react'
+import { Component } from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 import mapValues from './utils/mapValues'

--- a/src/packages/recompose/withPropsOnChange.js
+++ b/src/packages/recompose/withPropsOnChange.js
@@ -1,5 +1,6 @@
-import { createFactory, Component } from 'react'
+import { Component } from 'react'
 import { polyfill } from 'react-lifecycles-compat'
+import createFactory from './utils/createFactory'
 import pick from './utils/pick'
 import shallowEqual from './shallowEqual'
 import setDisplayName from './setDisplayName'

--- a/src/packages/recompose/withReducer.js
+++ b/src/packages/recompose/withReducer.js
@@ -1,4 +1,5 @@
-import { createFactory, Component } from 'react'
+import { Component } from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 

--- a/src/packages/recompose/withState.js
+++ b/src/packages/recompose/withState.js
@@ -1,4 +1,5 @@
-import { createFactory, Component } from 'react'
+import { Component } from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 

--- a/src/packages/recompose/withStateHandlers.js
+++ b/src/packages/recompose/withStateHandlers.js
@@ -1,4 +1,5 @@
-import { createFactory, Component } from 'react'
+import { Component } from 'react'
+import createFactory from './utils/createFactory'
 import setDisplayName from './setDisplayName'
 import wrapDisplayName from './wrapDisplayName'
 import mapValues from './utils/mapValues'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6793,7 +6793,7 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@^1.0.0, upath@^1.0.5, upath@^1.1.0:
+upath@^1.0.0, upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 


### PR DESCRIPTION
https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-reactcreatefactory

> React.createFactory is a legacy helper for creating React elements. This release adds a deprecation warning to the method. It will be removed in a future major version.